### PR TITLE
MAINT: Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clean:
 
 rundir:
 	mkdir -p ${RUNDIR}/UA
-	cd ${RUNDIR} ; mkdir UA/output ; ln -s UA/outputs . ; cd -
+	cd ${RUNDIR} ; mkdir UA/output ; ln -s UA/output . ; cd -
 	cd ${RUNDIR}/UA ; mkdir restartOut ; cd -
 	cd ${RUNDIR}/UA ; ln -s restartOut restartIn ; cd -
 	mkdir -p ${RUNDIR}/UA/inputs ; cp inputs/* ${RUNDIR}/UA/inputs

--- a/src/Makefile
+++ b/src/Makefile
@@ -29,7 +29,8 @@ OBJECTS = \
 	file_input.o\
 	fill_grid.o\
 	init_geo_grid.o\
-	output.o\
+	output_binary.o\
+	output_netcdf.o\
 	read_f107_file.o\
 	read_input_file.o\
 	read_omni_file.o\


### PR DESCRIPTION
# Description

Fixed compilation error when executing `make` at (removed?) `output.o` file:

`make[1]: *** No rule to make target 'output.o', needed by 'LIB'.  Stop.`

Also fixed typo causing a broken symbolic link to output directory when executing `make rundir`.

## Type of change

- Bug fix (non-breaking change that fixes an issue)


# How Has This Been Tested?

Followed the compilation steps in the README and the `aether.exe` executable is successfully produced and executes:

`./aether.exe`

## Test configuration

* Operating system: Ubuntu 18.04.5 LTS
* Compiler, version number: gcc 7.5.0

# Checklist:

- [X] Make sure you are merging into the ``develop`` (not ``master``) branch
- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [N/A] Add a note to ``CHANGELOG.md``, summarizing the changes

(sorry if I did not follow the contributing guidelines - please feel free to close / ignore if that is the case)