### PR TITLE
Updated netCDF variable names to remove ambiguity

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -79,7 +79,7 @@ int output(const Neutrals &neutrals,
                      "degrees_north",
                      grid.geoLat_scgc * cRtoD);
       AllOutputContainers[iOutput].
-      store_variable("z",
+      store_variable("alt",
                      "height above mean sea level",
                      "m",
                      grid.geoAlt_scgc);
@@ -720,8 +720,8 @@ int OutputContainer::write_container_netcdf() {
   try {
     NcFile ncdf_file(whole_filename, NcFile::replace);
     // Add dimensions:
-    NcDim xDim = ncdf_file.addDim("lon", elements[0].value.n_rows);
-    NcDim yDim = ncdf_file.addDim("lat", elements[0].value.n_cols);
+    NcDim xDim = ncdf_file.addDim("x", elements[0].value.n_rows);
+    NcDim yDim = ncdf_file.addDim("y", elements[0].value.n_cols);
     NcDim zDim = ncdf_file.addDim("z", elements[0].value.n_slices);
     NcDim tDim = ncdf_file.addDim("time", 1);
 


### PR DESCRIPTION
# Description
Updated netCDF output file creation to remove variable and dimension name ambiguity so outputs work with panoply and xarray.

## Type of change
- Bug fix (non-breaking change that fixes an issue)

# How Has This Been Tested?
The netCDF output files now work as expected in panoply and with xarray.

# Checklist:
- [N/A] Make sure you are merging into the ``develop`` (not ``master``) branch
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [N/A] Add a note to ``CHANGELOG.md``, summarizing the changes 
