### PR TITLE
BUG: Use horizontal BCs if no neighbor

### DIFF
--- a/include/neutrals.h
+++ b/include/neutrals.h
@@ -252,6 +252,14 @@ class Neutrals {
   void set_bcs(Report &report);
 
   /**********************************************************************
+     \brief Set boundary conditions for the neutrals
+     \param iDir direction of the BC to set
+     \param grid The grid to define the neutrals on
+     \param report allow reporting to occur
+  **/
+  void set_horizontal_bcs(int64_t iDir, Grid grid, Report &report);
+  
+  /**********************************************************************
      \brief Get the species ID number (int) given the species name (string)
      \param name string holding the species name (e.g., "O+")
      \param report allow reporting to occur

--- a/src/init_geo_grid.cpp
+++ b/src/init_geo_grid.cpp
@@ -246,10 +246,10 @@ void Grid::create_sphere_connection(Quadtree quadtree,
   arma_vec size_up_norm = quadtree.get_vect("SU");
 
   // Move to the next block in 4 directions:
-  arma_vec down_norm = middle_norm - size_up_norm;
-  arma_vec up_norm = middle_norm + size_up_norm;
-  arma_vec left_norm = middle_norm - size_right_norm;
-  arma_vec right_norm = middle_norm + size_right_norm;
+  arma_vec down_norm = middle_norm - 0.51 * size_up_norm;
+  arma_vec up_norm = middle_norm + 0.51 * size_up_norm;
+  arma_vec left_norm = middle_norm - 0.51 * size_right_norm;
+  arma_vec right_norm = middle_norm + 0.51 * size_right_norm;
 
   // The first component could wrap around:
   right_norm(0) = fmod(right_norm(0), quadtree.limit_high(0));

--- a/src/neutrals.cpp
+++ b/src/neutrals.cpp
@@ -352,6 +352,109 @@ void Neutrals::set_bcs(Report &report) {
 }
 
 //----------------------------------------------------------------------
+// set_horizontal_bcs
+//   iDir tells which direction to set:
+//      iDir = 0 -> +x
+//      iDir = 1 -> +y
+//      iDir = 2 -> -x
+//      iDir = 3 -> -y
+//----------------------------------------------------------------------
+
+void Neutrals::set_horizontal_bcs(int64_t iDir, Grid grid, Report &report) {
+
+  std::string function = "Neutrals::set_horizontal_bcs";
+  static int iFunction = -1;
+  report.enter(function, iFunction);
+
+  int64_t nX = grid.get_nX(), iX;
+  int64_t nY = grid.get_nY(), iY;
+  int64_t nAlts = grid.get_nAlts(), iAlt;
+  int64_t nGCs = grid.get_nGCs();
+  int64_t iV;
+
+  // iDir = 0 is right BC:
+  if (iDir == 0) {
+    for (iX = nX - nGCs; iX < nX; iX++) {
+      for (iY = 0; iY < nY; iY++) {
+        // Constant Gradient for Temperature:
+        temperature_scgc.tube(iX, iY) =
+          2 * temperature_scgc.tube(iX - 1, iY) -
+          temperature_scgc.tube(iX - 2, iY);
+        // Constant Value for Velocity:
+        for (iV = 0; iV < 3; iV++)
+          velocity_vcgc[iV].tube(iX, iY) = velocity_vcgc[iV].tube(iX - 1, iY);
+        // Constant Gradient for densities:
+        for (int iSpecies = 0; iSpecies < nSpecies; iSpecies++)
+          species[iSpecies].density_scgc.tube(iX, iY) =
+            2 * species[iSpecies].density_scgc.tube(iX-1, iY) -
+            species[iSpecies].density_scgc.tube(iX-2, iY);
+      }
+    }
+  }
+
+  // iDir = 2 is left BC:
+  if (iDir == 2) {
+    for (iX = nGCs - 1; iX >= 0; iX--) {
+      for (iY = 0; iY < nY; iY++) {
+        // Constant Gradient for Temperature:
+        temperature_scgc.tube(iX, iY) =
+          2 * temperature_scgc.tube(iX + 1, iY) -
+          temperature_scgc.tube(iX + 2, iY);
+        // Constant Value for Velocity:
+        for (iV = 0; iV < 3; iV++)
+          velocity_vcgc[iV].tube(iX, iY) = velocity_vcgc[iV].tube(iX + 1, iY);
+        // Constant Gradient for densities:
+        for (int iSpecies = 0; iSpecies < nSpecies; iSpecies++)
+          species[iSpecies].density_scgc.tube(iX, iY) =
+            2 * species[iSpecies].density_scgc.tube(iX + 1, iY) -
+            species[iSpecies].density_scgc.tube(iX + 2, iY);
+      }
+    }
+  }
+
+  // iDir = 1 is upper BC:
+  if (iDir == 1) {
+    for (iX = 0; iX < nX; iX++) {
+      for (iY = nX - nGCs; iY < nY; iY++) {
+        // Constant Gradient for Temperature:
+        temperature_scgc.tube(iX, iY) =
+          2 * temperature_scgc.tube(iX, iY - 1) -
+          temperature_scgc.tube(iX, iY - 2);
+        // Constant Value for Velocity:
+        for (iV = 0; iV < 3; iV++)
+          velocity_vcgc[iV].tube(iX, iY) = velocity_vcgc[iV].tube(iX, iY - 1);
+        // Constant Gradient for densities:
+        for (int iSpecies = 0; iSpecies < nSpecies; iSpecies++)
+          species[iSpecies].density_scgc.tube(iX, iY) =
+            2 * species[iSpecies].density_scgc.tube(iX, iY - 1) -
+            species[iSpecies].density_scgc.tube(iX, iY - 2);
+      }
+    }
+  }
+
+  // iDir = 2 is left BC:
+  if (iDir == 3) {
+    for (iX = 0; iX < nX; iX++) {
+      for (iY = nGCs - 1; iY >= 0; iY--) {
+        // Constant Gradient for Temperature:
+        temperature_scgc.tube(iX, iY) =
+          2 * temperature_scgc.tube(iX, iY + 1) -
+          temperature_scgc.tube(iX, iY + 2);
+        // Constant Value for Velocity:
+        for (iV = 0; iV < 3; iV++)
+          velocity_vcgc[iV].tube(iX, iY) = velocity_vcgc[iV].tube(iX, iY + 1);
+        // Constant Gradient for densities:
+        for (int iSpecies = 0; iSpecies < nSpecies; iSpecies++)
+          species[iSpecies].density_scgc.tube(iX, iY) =
+            2 * species[iSpecies].density_scgc.tube(iX, iY + 1) -
+            species[iSpecies].density_scgc.tube(iX, iY + 2);
+      }
+    }
+  }
+  report.exit(function);
+}
+
+//----------------------------------------------------------------------
 // return the index of the requested species
 // This will return -1 if the species is not found or name is empty
 //----------------------------------------------------------------------


### PR DESCRIPTION
# Description

There is no issues that it addresses....

We discovered yesterday that the code crashes on Linux machines, but doesn't crash on Macs (where I do development).  After debugging a bit, I found out that when running on one processor, it doesn't exchange over the poles (which is fine, since this is complicated), but it crashes.  I wrote a horizontal boundary condition code and set it to call horizontal BCs if the processor that it is supposed to exchange with is set to -1. This allows partial planets to be simulated also.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change that fixes an issue) - fixes the crash
- New feature (non-breaking change that adds functionality) - implements horizontal BCs

# How Has This Been Tested?

Ran the nominal 1 processor run on a linux box and it works now.

## Test configuration

* Operating system: Ubuntu
* Compiler, version number: gcc v11

# Checklist:

- [X] Make sure you are merging into the ``develop`` (not ``master``) branch
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [N/A] Add a note to ``CHANGELOG.md``, summarizing the changes
