### PR TITLE
BUG: Use horizontal BCs if no neighbor

### DIFF
--- a/include/neutrals.h
+++ b/include/neutrals.h
@@ -252,6 +252,14 @@ class Neutrals {
   void set_bcs(Report &report);
 
   /**********************************************************************
+     \brief Set boundary conditions for the neutrals
+     \param iDir direction of the BC to set
+     \param grid The grid to define the neutrals on
+     \param report allow reporting to occur
+  **/
+  void set_horizontal_bcs(int64_t iDir, Grid grid, Report &report);
+  
+  /**********************************************************************
      \brief Get the species ID number (int) given the species name (string)
      \param name string holding the species name (e.g., "O+")
      \param report allow reporting to occur

--- a/share/examples/aether_partial.json
+++ b/share/examples/aether_partial.json
@@ -1,0 +1,36 @@
+
+{
+
+    "Debug" : {
+	"iVerbose" : 0,
+	"dt" : 10.0},
+
+    "Outputs" : {
+	"type" : ["states"],
+	"dt" : [300] },
+    
+    "CubeSphere" : {
+	"false" : true},
+
+    "GeoGrid" : {
+	"MinLat" :  30.0,
+	"MaxLat" :  60.0,
+	"MinLon" :  90.0,
+	"MaxLon" : 270.0,
+	"MinAlt" : 100.0,
+	"dAlt"   : 5.0,
+        "AltFile" : "",
+	"IsUniformAlt" : true},
+    
+    "GeoBlockSize" : {
+	"nLons" : 30,
+	"nLats" : 15,
+	"nAlts" : 50},
+
+    "StartTime" : [2011, 3, 20, 0, 0, 0],
+    "EndTime" : [2011, 3, 20, 1, 0, 0],
+
+    "OmniwebFiles" : ["UA/inputs/omni_20110319.txt"],
+    "ElectrodynamicsFile" : "UA/inputs/b20110320n_omni.bin"
+
+}

--- a/src/calc_ion_temperature.cpp
+++ b/src/calc_ion_temperature.cpp
@@ -56,7 +56,7 @@ void Ions::calc_ion_temperature(Neutrals neutrals, Grid grid,
   // Loop over all species or assume only bulk calculation
   if (input.get_do_calc_bulk_ion_temp())
     // First ion species only, currently is O+
-    nSpecs = 1; 
+    nSpecs = 1;
   else
     nSpecs = nIons;
 
@@ -72,14 +72,14 @@ void Ions::calc_ion_temperature(Neutrals neutrals, Grid grid,
       for (iLat = 0; iLat < nLats; iLat++) {
 
         // ---------------------------------------------------------------------
-        // Calculate heat flux (conduction) in 1D; loop over all lat,lon 
+        // Calculate heat flux (conduction) in 1D; loop over all lat,lon
         // ---------------------------------------------------------------------
-        temp1d   = species[iIon].temperature_scgc.tube(iLon, iLat);   
-	lambda1d = 25.0 * pow(cKB, 2) * pow(temp1d, 2.5) / species[iIon].mass
-                   / species[iIon].nu_ion_ion[iIon] / 8.0; 
-        front1d  = 2.0 / species[iIon].density_scgc.tube(iLon, iLat) 
-		   / cKB / 3.0; 
-        dalt1d   = grid.dalt_lower_scgc.tube(iLon, iLat); 
+        temp1d   = species[iIon].temperature_scgc.tube(iLon, iLat);
+        lambda1d = 25.0 * pow(cKB, 2) * pow(temp1d, 2.5) / species[iIon].mass
+                   / species[iIon].nu_ion_ion[iIon] / 8.0;
+        front1d  = 2.0 / species[iIon].density_scgc.tube(iLon, iLat)
+                   / cKB / 3.0;
+        dalt1d   = grid.dalt_lower_scgc.tube(iLon, iLat);
 
         conduction1d.zeros();    // reset temp variable to zero
 
@@ -109,9 +109,9 @@ void Ions::calc_ion_temperature(Neutrals neutrals, Grid grid,
 
     for (iIon = 0; iIon < nIons; iIon++) {
       tempT = tempT +
-	species[iIon].temperature_scgc % species[iIon].density_scgc;
+              species[iIon].temperature_scgc % species[iIon].density_scgc;
       tempD = tempD +
-	species[iIon].density_scgc;
+              species[iIon].density_scgc;
     }
 
     temperature_scgc = tempT / tempD;

--- a/src/electrodynamics.cpp
+++ b/src/electrodynamics.cpp
@@ -349,9 +349,10 @@ arma_mat Electrodynamics::get_interpolation_indices(arma_mat vals,
 
       // Check to see if the time is below or above the vector:
 
-      if (in < search(iLow) || in > search(iHigh)) {
+      if (in < search(iLow) || in > search(iHigh))
         interpolation_index = 0.0;
-      } else {
+
+      else {
 
         // At this point, we know that it is somewhere between the highest
         // and lowest values:
@@ -384,6 +385,7 @@ arma_mat Electrodynamics::get_interpolation_indices(arma_mat vals,
 
         interpolation_index = iMid + x;
       }
+
       res(i, j) = interpolation_index;
     }
   }

--- a/src/exchange_messages.cpp
+++ b/src/exchange_messages.cpp
@@ -326,7 +326,7 @@ bool Neutrals::unpack_one_face(int iSender,
 bool Grid::send_one_face(int64_t iFace) {
 
   bool DidWork = true;
-  
+
   MPI_Isend(interchanges[iFace].buffer,
             interchanges[iFace].iSizeTotal,
             MPI_BYTE,
@@ -605,14 +605,13 @@ bool Neutrals::exchange(Grid &grid, Report &report) {
   for (int iDir = 0; iDir < 4; iDir++) {
     if (grid.interchanges[iDir].iProc_to >= 0) {
       DidWork = unpack_one_face(grid.interchanges[iDir].iProc_to,
-				grid.interchanges[iDir].rbuffer,
-				nG, iDir,
-				grid.interchanges[iDir].DoReverseX,
-				grid.interchanges[iDir].DoReverseY,
-				grid.interchanges[iDir].XbecomesY);
-    } else {
+                                grid.interchanges[iDir].rbuffer,
+                                nG, iDir,
+                                grid.interchanges[iDir].DoReverseX,
+                                grid.interchanges[iDir].DoReverseY,
+                                grid.interchanges[iDir].XbecomesY);
+    } else
       set_horizontal_bcs(iDir, grid, report);
-    }
   }
 
   // Wait for all processors to be done.

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -208,7 +208,7 @@ bool Grid::read_restart(std::string dir) {
     RestartContainer.set_filename("grid_below_" + cGrid);
     RestartContainer.read_container_netcdf();
     geoAlt_Below = RestartContainer.get_element_value(altitude_name +
-                                                       " Below");
+                                                      " Below");
     // Cell Corners:
     RestartContainer.set_filename("grid_corners_" + cGrid);
     RestartContainer.read_container_netcdf();
@@ -222,16 +222,16 @@ bool Grid::read_restart(std::string dir) {
     RestartContainer.set_filename("grid_left_" + cGrid);
     RestartContainer.read_container_netcdf();
     geoLon_Left = RestartContainer.get_element_value(longitude_name +
-                                                       " Left");
+                                                     " Left");
     geoLat_Left = RestartContainer.get_element_value(latitude_name +
-                                                       " Left");
+                                                     " Left");
     // Down Edges:
     RestartContainer.set_filename("grid_down_" + cGrid);
     RestartContainer.read_container_netcdf();
     geoLon_Down = RestartContainer.get_element_value(longitude_name +
-                                                       " Down");
+                                                     " Down");
     geoLat_Down = RestartContainer.get_element_value(latitude_name +
-                                                       " Down");
+                                                     " Down");
 
   } catch (...) {
     std::cout << "Error reading grid restart file!\n";

--- a/src/init_geo_grid.cpp
+++ b/src/init_geo_grid.cpp
@@ -246,10 +246,10 @@ void Grid::create_sphere_connection(Quadtree quadtree,
   arma_vec size_up_norm = quadtree.get_vect("SU");
 
   // Move to the next block in 4 directions:
-  arma_vec down_norm = middle_norm - size_up_norm;
-  arma_vec up_norm = middle_norm + size_up_norm;
-  arma_vec left_norm = middle_norm - size_right_norm;
-  arma_vec right_norm = middle_norm + size_right_norm;
+  arma_vec down_norm = middle_norm - 0.51 * size_up_norm;
+  arma_vec up_norm = middle_norm + 0.51 * size_up_norm;
+  arma_vec left_norm = middle_norm - 0.51 * size_right_norm;
+  arma_vec right_norm = middle_norm + 0.51 * size_right_norm;
 
   // The first component could wrap around:
   right_norm(0) = fmod(right_norm(0), quadtree.limit_high(0));

--- a/src/init_geo_grid.cpp
+++ b/src/init_geo_grid.cpp
@@ -493,6 +493,7 @@ bool Grid::init_geo_grid(Quadtree quadtree,
       create_cubesphere_grid(quadtree, input, report);
     else
       create_sphere_grid(quadtree, input, report);
+
     create_altitudes(input, report);
 
     DidWork = write_restart(input.get_restartout_dir());

--- a/src/inputs.cpp
+++ b/src/inputs.cpp
@@ -453,7 +453,7 @@ std::string Inputs::get_electrodynamics_file() {
 }
 
 // -----------------------------------------------------------------------
-// Flag to do the bulk ion temperature calculation instead 
+// Flag to do the bulk ion temperature calculation instead
 // of individual ion specie temperature calculations
 // -----------------------------------------------------------------------
 

--- a/src/neutrals.cpp
+++ b/src/neutrals.cpp
@@ -352,6 +352,109 @@ void Neutrals::set_bcs(Report &report) {
 }
 
 //----------------------------------------------------------------------
+// set_horizontal_bcs
+//   iDir tells which direction to set:
+//      iDir = 0 -> +x
+//      iDir = 1 -> +y
+//      iDir = 2 -> -x
+//      iDir = 3 -> -y
+//----------------------------------------------------------------------
+
+void Neutrals::set_horizontal_bcs(int64_t iDir, Grid grid, Report &report) {
+
+  std::string function = "Neutrals::set_horizontal_bcs";
+  static int iFunction = -1;
+  report.enter(function, iFunction);
+
+  int64_t nX = grid.get_nX(), iX;
+  int64_t nY = grid.get_nY(), iY;
+  int64_t nAlts = grid.get_nAlts(), iAlt;
+  int64_t nGCs = grid.get_nGCs();
+  int64_t iV;
+
+  // iDir = 0 is right BC:
+  if (iDir == 0) {
+    for (iX = nX - nGCs; iX < nX; iX++) {
+      for (iY = 0; iY < nY; iY++) {
+        // Constant Gradient for Temperature:
+        temperature_scgc.tube(iX, iY) =
+          2 * temperature_scgc.tube(iX - 1, iY) -
+          temperature_scgc.tube(iX - 2, iY);
+        // Constant Value for Velocity:
+        for (iV = 0; iV < 3; iV++)
+          velocity_vcgc[iV].tube(iX, iY) = velocity_vcgc[iV].tube(iX - 1, iY);
+        // Constant Gradient for densities:
+        for (int iSpecies = 0; iSpecies < nSpecies; iSpecies++)
+          species[iSpecies].density_scgc.tube(iX, iY) =
+            2 * species[iSpecies].density_scgc.tube(iX-1, iY) -
+            species[iSpecies].density_scgc.tube(iX-2, iY);
+      }
+    }
+  }
+
+  // iDir = 2 is left BC:
+  if (iDir == 2) {
+    for (iX = nGCs - 1; iX >= 0; iX--) {
+      for (iY = 0; iY < nY; iY++) {
+        // Constant Gradient for Temperature:
+        temperature_scgc.tube(iX, iY) =
+          2 * temperature_scgc.tube(iX + 1, iY) -
+          temperature_scgc.tube(iX + 2, iY);
+        // Constant Value for Velocity:
+        for (iV = 0; iV < 3; iV++)
+          velocity_vcgc[iV].tube(iX, iY) = velocity_vcgc[iV].tube(iX + 1, iY);
+        // Constant Gradient for densities:
+        for (int iSpecies = 0; iSpecies < nSpecies; iSpecies++)
+          species[iSpecies].density_scgc.tube(iX, iY) =
+            2 * species[iSpecies].density_scgc.tube(iX + 1, iY) -
+            species[iSpecies].density_scgc.tube(iX + 2, iY);
+      }
+    }
+  }
+
+  // iDir = 1 is upper BC:
+  if (iDir == 1) {
+    for (iX = 0; iX < nX; iX++) {
+      for (iY = nX - nGCs; iY < nY; iY++) {
+        // Constant Gradient for Temperature:
+        temperature_scgc.tube(iX, iY) =
+          2 * temperature_scgc.tube(iX, iY - 1) -
+          temperature_scgc.tube(iX, iY - 2);
+        // Constant Value for Velocity:
+        for (iV = 0; iV < 3; iV++)
+          velocity_vcgc[iV].tube(iX, iY) = velocity_vcgc[iV].tube(iX, iY - 1);
+        // Constant Gradient for densities:
+        for (int iSpecies = 0; iSpecies < nSpecies; iSpecies++)
+          species[iSpecies].density_scgc.tube(iX, iY) =
+            2 * species[iSpecies].density_scgc.tube(iX, iY - 1) -
+            species[iSpecies].density_scgc.tube(iX, iY - 2);
+      }
+    }
+  }
+
+  // iDir = 2 is left BC:
+  if (iDir == 3) {
+    for (iX = 0; iX < nX; iX++) {
+      for (iY = nGCs - 1; iY >= 0; iY--) {
+        // Constant Gradient for Temperature:
+        temperature_scgc.tube(iX, iY) =
+          2 * temperature_scgc.tube(iX, iY + 1) -
+          temperature_scgc.tube(iX, iY + 2);
+        // Constant Value for Velocity:
+        for (iV = 0; iV < 3; iV++)
+          velocity_vcgc[iV].tube(iX, iY) = velocity_vcgc[iV].tube(iX, iY + 1);
+        // Constant Gradient for densities:
+        for (int iSpecies = 0; iSpecies < nSpecies; iSpecies++)
+          species[iSpecies].density_scgc.tube(iX, iY) =
+            2 * species[iSpecies].density_scgc.tube(iX, iY + 1) -
+            species[iSpecies].density_scgc.tube(iX, iY + 2);
+      }
+    }
+  }
+  report.exit(function);
+}
+
+//----------------------------------------------------------------------
 // return the index of the requested species
 // This will return -1 if the species is not found or name is empty
 //----------------------------------------------------------------------

--- a/src/neutrals.cpp
+++ b/src/neutrals.cpp
@@ -380,14 +380,16 @@ void Neutrals::set_horizontal_bcs(int64_t iDir, Grid grid, Report &report) {
         temperature_scgc.tube(iX, iY) =
           2 * temperature_scgc.tube(iX - 1, iY) -
           temperature_scgc.tube(iX - 2, iY);
+
         // Constant Value for Velocity:
         for (iV = 0; iV < 3; iV++)
           velocity_vcgc[iV].tube(iX, iY) = velocity_vcgc[iV].tube(iX - 1, iY);
+
         // Constant Gradient for densities:
         for (int iSpecies = 0; iSpecies < nSpecies; iSpecies++)
           species[iSpecies].density_scgc.tube(iX, iY) =
-            2 * species[iSpecies].density_scgc.tube(iX-1, iY) -
-            species[iSpecies].density_scgc.tube(iX-2, iY);
+            2 * species[iSpecies].density_scgc.tube(iX - 1, iY) -
+            species[iSpecies].density_scgc.tube(iX - 2, iY);
       }
     }
   }
@@ -400,9 +402,11 @@ void Neutrals::set_horizontal_bcs(int64_t iDir, Grid grid, Report &report) {
         temperature_scgc.tube(iX, iY) =
           2 * temperature_scgc.tube(iX + 1, iY) -
           temperature_scgc.tube(iX + 2, iY);
+
         // Constant Value for Velocity:
         for (iV = 0; iV < 3; iV++)
           velocity_vcgc[iV].tube(iX, iY) = velocity_vcgc[iV].tube(iX + 1, iY);
+
         // Constant Gradient for densities:
         for (int iSpecies = 0; iSpecies < nSpecies; iSpecies++)
           species[iSpecies].density_scgc.tube(iX, iY) =
@@ -420,9 +424,11 @@ void Neutrals::set_horizontal_bcs(int64_t iDir, Grid grid, Report &report) {
         temperature_scgc.tube(iX, iY) =
           2 * temperature_scgc.tube(iX, iY - 1) -
           temperature_scgc.tube(iX, iY - 2);
+
         // Constant Value for Velocity:
         for (iV = 0; iV < 3; iV++)
           velocity_vcgc[iV].tube(iX, iY) = velocity_vcgc[iV].tube(iX, iY - 1);
+
         // Constant Gradient for densities:
         for (int iSpecies = 0; iSpecies < nSpecies; iSpecies++)
           species[iSpecies].density_scgc.tube(iX, iY) =
@@ -440,9 +446,11 @@ void Neutrals::set_horizontal_bcs(int64_t iDir, Grid grid, Report &report) {
         temperature_scgc.tube(iX, iY) =
           2 * temperature_scgc.tube(iX, iY + 1) -
           temperature_scgc.tube(iX, iY + 2);
+
         // Constant Value for Velocity:
         for (iV = 0; iV < 3; iV++)
           velocity_vcgc[iV].tube(iX, iY) = velocity_vcgc[iV].tube(iX, iY + 1);
+
         // Constant Gradient for densities:
         for (int iSpecies = 0; iSpecies < nSpecies; iSpecies++)
           species[iSpecies].density_scgc.tube(iX, iY) =
@@ -451,6 +459,7 @@ void Neutrals::set_horizontal_bcs(int64_t iDir, Grid grid, Report &report) {
       }
     }
   }
+
   report.exit(function);
 }
 

--- a/src/read_collision_file.cpp
+++ b/src/read_collision_file.cpp
@@ -382,8 +382,8 @@ void parse_bst_in_table(std::vector<std::vector<std::string>> csv,
                       << csv[iLine][0] << " and " << csv[0][iCol] << "\n";
             std::cout << "nu_ion_ion     : "
                       << ions.species[iIonT].nu_ion_ion[iIonSIds_[iCol - 1]] << "\n";
-	  }
-	}  // End iIonSIds_
+          }
+        }  // End iIonSIds_
       }  // End iCol
     }  // End iIonT
   }  // End iLine

--- a/srcPython/postAether.py
+++ b/srcPython/postAether.py
@@ -110,6 +110,8 @@ def plot_block(data, varToPlot, altToPlot, ax, mini, maxi, i):
     iLon = find_var_index(data['vars'], 'lon')
     iLat = find_var_index(data['vars'], 'lat')
     iAlt = find_var_index(data['vars'], 'z')
+    if (iAlt == -1):
+        iAlt = find_var_index(data['vars'], 'alt')
     iVar = find_var_index(data['vars'], varToPlot)
 
     if (mini < 0):
@@ -202,6 +204,9 @@ def plot_all_blocks(allBlockData, varToPlot, altToPlot, plotFile):
         if (i < 100):
             plot_block(data, varToPlot, altToPlot, ax, mini, maxi, i)
         i = i+1
+    ax.set_title(varToPlot)
+    ax.set_xlabel('Longitude (deg)')
+    ax.set_ylabel('Latitude (deg)')
     print('  Outputting file : ', plotFile)
     fig.savefig(plotFile)
     plt.close(fig)

--- a/tests/partial_planet/run_test.sh
+++ b/tests/partial_planet/run_test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+export TEST=partial
+export DIR=./run.$TEST
+
+rm -rf $DIR
+
+cp -R ../../share/run $DIR
+cd $DIR
+rm -f ./aether.json
+cp ../../../share/examples/aether_$TEST.json ./aether.json
+mpirun -np 4 ./aether
+# plot the output
+cd UA/output
+../../../../../srcPython/postAether.py -rm
+
+# not going to make any other plots, due to z - alt incompatability
+# [O]:
+#run_plot_block_model_results.py -var=O -alt=30 3DALL_20110320_001000.nc
+# Tn:
+#run_plot_block_model_results.py -var=Temperature -alt=30 3DALL_20110320_001000.nc
+# [e-]
+#run_plot_block_model_results.py -var=e- -alt=5 3DALL_20110320_001000.nc


### PR DESCRIPTION
# Description

Addresses no issues, since this was discovered as I was running things.

If Aether is running a partial planet, then horizontal boundary conditions need to be set.  These code changes do the following:
1. Modify the code to see if horizontal BCs are needed (as opposed to message passing).
2. Implement horizontal BCs in the neutrals. 

## Type of change

Please delete options that are not relevant.

- Bug fix: Code didn't accurately know when there was a partial planet.
- New feature: Horizontal BCs are implemented.
- This change requires a documentation update

# How Has This Been Tested?

Test created in the tests/partial_planet directory.  Go into this directory and type 
./run_test.sh
Cross fingers.  Look at the output in UA/output/*png files.

## Test configuration

* Operating system: OSX 10.15
* Compiler, version number: gcc version 10.4.0 (MacPorts gcc10 10.4.0_1) 

# Checklist:

- [N/A] Make sure you are merging into the ``develop`` (not ``master``) branch
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [N/A] Add a note to ``CHANGELOG.md``, summarizing the changes
