### PR TITLE
[FEAT] Setting function specific verbose levels

### DIFF
--- a/doc/debug.md
+++ b/doc/debug.md
@@ -1,9 +1,41 @@
 
+The Debug command in the input file sets the type and amount of
+information that is fed to the user. An example of the Debug command
+is:
+
+    "Debug" : {
+	"iVerbose" : 0,
+	"dt" : 60.0,
+	"TimingPercent" : 1.0,
+	"iTimingDepth" : 5,
+	"iProc" : 0},
+
 The "iVerbose" command can be used under "Debug" in aether.json to set
-the overall verbose level in the code. Optionally, users can also
-assign specific verbose levels to be used for certain functions by
-specifying the function names and the corresponding verbose levels
-using the "iFunctionVerbose" command as follows:
+the overall verbose level in the code.  This sets the amount of
+debugging information that is output.  In addition, many functions
+report when they are entered (and existed).  These functions
+automatically report when the depth of the function is less than
+iVerbose.
+
+Because Aether is a parallel code, users typically don't want to see
+output from all processors, so the user can specify which processor
+outputs using "iProc".
+
+"dt" specifies how often to report timing information and is in
+seconds in simulation time (not walltime).
+
+The "Timing" variables specify how much information is passed to the
+user for code profiling at the end of the simulation.  These variables
+limit the amount of information.  For example, "iTimingDepth" limits
+the reporting of timing for functions by depth of call.
+"TimingPercent" specifies to report the timing only if the time that
+the function took was larger than the TimingPercent of the total
+run-time.
+
+Users can assign specific verbose levels to be used for
+certain functions by specifying the function names and the
+corresponding verbose levels using the "iFunctionVerbose" command as
+follows:
 
     "Debug" : {
     "iVerbose" : 0,

--- a/doc/debug.md
+++ b/doc/debug.md
@@ -1,0 +1,19 @@
+
+The "iVerbose" command can be used under "Debug" in aether.json to set
+the overall verbose level in the code. Optionally, users can also
+assign specific verbose levels to be used for certain functions by
+specifying the function names and the corresponding verbose levels
+using the "iFunctionVerbose" command as follows:
+
+    "Debug" : {
+    "iVerbose" : 0,
+    "iFunctionVerbose" : {
+        "func1" : 1,
+        "func2" : 2},
+    "dt" : 10.0
+    }
+
+When a sub-function is entered, the verbose level stays the same if
+the verbose level for that sub-function is not specified. When that
+sub-function exits, the verbose level will accordingly be set back to
+that of the function it is returning to.

--- a/include/report.h
+++ b/include/report.h
@@ -73,6 +73,12 @@ public:
   void set_DefaultVerbose(int input);
 
   /**************************************************************
+   \brief This sets the flag to have sub-functions inherit verbose levels
+   \param input the flag to have sub-functions inherit verbose levels
+   **/
+  void set_doInheritVerbose(bool input);
+
+  /**************************************************************
    \brief This sets the verbose level for the specified function
    \param input the function name
    \param iFunctionVerbose verbose level for the specified function
@@ -113,6 +119,11 @@ public:
    \brief Returns the default "iVerbose" passed in Aether.json
    **/
   int get_DefaultVerbose();
+
+  /**************************************************************
+   \brief Returns the flag to have sub-functions inherit verbose levels
+   **/
+  bool get_doInheritVerbose();
 
   /**************************************************************
    \brief Returns the verbose level for the specified function
@@ -172,6 +183,8 @@ private:
   int iProcReport;
   /// default "iVerbose" that is passed in Aether.json
   int iDefaultVerbose;
+  /// flag to have sub-functions inherit verbose levels of functions
+  bool doInheritVerbose;
   /// map to store the verbose levels of the specified functions
   std::map<std::string, int> map_iFunctionVerbose;
   /// the depth of the reporting for the timing at the end of the simulation

--- a/include/report.h
+++ b/include/report.h
@@ -61,6 +61,12 @@ public:
   void set_verbose(int input);
 
   /**************************************************************
+   \brief Set which processor does the reporting
+   \param input the processor to do the reporting
+   **/
+  void set_iProc(int input);
+
+  /**************************************************************
    \brief This sets the default "iVerbose" that is passed in Aether.json
    \param input the default "iVerbose" value
    **/
@@ -162,6 +168,8 @@ private:
 
   /// global verbose level of the code
   int iVerbose;
+  /// processor to do the reporting
+  int iProcReport;
   /// default "iVerbose" that is passed in Aether.json
   int iDefaultVerbose;
   /// map to store the verbose levels of the specified functions

--- a/include/report.h
+++ b/include/report.h
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <vector>
+#include <map>
 
 #include "aether.h"
 
@@ -60,6 +61,19 @@ public:
   void set_verbose(int input);
 
   /**************************************************************
+   \brief This sets the default "iVerbose" that is passed in Aether.json
+   \param input the default "iVerbose" value
+   **/
+  void set_DefaultVerbose(int input);
+
+  /**************************************************************
+   \brief This sets the verbose level for the specified function
+   \param input the function name
+   \param iFunctionVerbose verbose level for the specified function
+   **/
+  void set_FunctionVerbose(std::string input, int iFunctionVerbose);
+
+  /**************************************************************
    \brief How deep to go in the timing report at the end of the run
    \param input the timing depth to be set for the code
    **/
@@ -88,6 +102,17 @@ public:
    \brief Returns the global verbosity of the code
    **/
   int get_verbose();
+
+  /**************************************************************
+   \brief Returns the default "iVerbose" passed in Aether.json
+   **/
+  int get_DefaultVerbose();
+
+  /**************************************************************
+   \brief Returns the verbose level for the specified function
+   \param input the name of the function
+   **/
+  int get_FunctionVerbose(std::string input);
 
   /**************************************************************
    \brief sends a message to a student about the function name
@@ -137,6 +162,10 @@ private:
 
   /// global verbose level of the code
   int iVerbose;
+  /// default "iVerbose" that is passed in Aether.json
+  int iDefaultVerbose;
+  /// map to store the verbose levels of the specified functions
+  std::map<std::string, int> map_iFunctionVerbose;
   /// the depth of the reporting for the timing at the end of the simulation
   int iTimingDepth;
   /// Only report times above the given percentage of the total run time:
@@ -161,6 +190,8 @@ private:
     /// This is the function that was called just before this one, so that
     /// if can be "popped" of the queue:
     int iLastEntry;
+    /// This is an int that holds the Verbose level of the function
+    int iFunctionVerbose;
   };
 
   /// A vector of entries to keep track of during the model run

--- a/share/run/UA/inputs/defaults.json
+++ b/share/run/UA/inputs/defaults.json
@@ -2,6 +2,7 @@
 {
     "Debug" : {
 	"iVerbose" : 0,
+	"doInheritVerbose" : false,
 	"dt" : 60.0,
 	"TimingPercent" : 1.0,
 	"iTimingDepth" : 5,

--- a/src/init_parallel.cpp
+++ b/src/init_parallel.cpp
@@ -41,8 +41,10 @@ bool init_parallel(Inputs &input,
 
   // Modify the verbosity of the code by turning of verbose on all
   // processors except specified processor:
-  if (iProc != input.get_verbose_proc())
+  if (iProc != input.get_verbose_proc()) {
     report.set_verbose(-1);
+    report.set_DefaultVerbose(-1);
+  }
 
   nMembers = input.get_nMembers();
   nGrids = nProcs / nMembers;

--- a/src/read_input_file.cpp
+++ b/src/read_input_file.cpp
@@ -63,9 +63,8 @@ bool Inputs::read_inputs_json(Times &time, Report &report) {
     report.set_timing_depth(settings["Debug"]["iTimingDepth"]);
     report.set_timing_percent(settings["Debug"]["TimingPercent"]);
 
-    for (auto &item : settings["Debug"]["iFunctionVerbose"].items()) {
+    for (auto &item : settings["Debug"]["iFunctionVerbose"].items())
       report.set_FunctionVerbose(item.key(), item.value());
-    }
 
     // Capture time information:
     std::vector<int> istart = get_settings_timearr("StartTime");

--- a/src/read_input_file.cpp
+++ b/src/read_input_file.cpp
@@ -60,6 +60,7 @@ bool Inputs::read_inputs_json(Times &time, Report &report) {
     // Debug Stuff:
     report.set_verbose(settings["Debug"]["iVerbose"]);
     report.set_DefaultVerbose(settings["Debug"]["iVerbose"]);
+    report.set_doInheritVerbose(settings["Debug"]["doInheritVerbose"]);
     report.set_timing_depth(settings["Debug"]["iTimingDepth"]);
     report.set_timing_percent(settings["Debug"]["TimingPercent"]);
     report.set_iProc(settings["Debug"]["iProc"]);

--- a/src/read_input_file.cpp
+++ b/src/read_input_file.cpp
@@ -59,8 +59,13 @@ bool Inputs::read_inputs_json(Times &time, Report &report) {
 
     // Debug Stuff:
     report.set_verbose(settings["Debug"]["iVerbose"]);
+    report.set_DefaultVerbose(settings["Debug"]["iVerbose"]);
     report.set_timing_depth(settings["Debug"]["iTimingDepth"]);
     report.set_timing_percent(settings["Debug"]["TimingPercent"]);
+
+    for (auto &item : settings["Debug"]["iFunctionVerbose"].items()) {
+      report.set_FunctionVerbose(item.key(), item.value());
+    }
 
     // Capture time information:
     std::vector<int> istart = get_settings_timearr("StartTime");

--- a/src/read_input_file.cpp
+++ b/src/read_input_file.cpp
@@ -62,6 +62,7 @@ bool Inputs::read_inputs_json(Times &time, Report &report) {
     report.set_DefaultVerbose(settings["Debug"]["iVerbose"]);
     report.set_timing_depth(settings["Debug"]["iTimingDepth"]);
     report.set_timing_percent(settings["Debug"]["TimingPercent"]);
+    report.set_iProc(settings["Debug"]["iProc"]);
 
     for (auto &item : settings["Debug"]["iFunctionVerbose"].items())
       report.set_FunctionVerbose(item.key(), item.value());

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -56,11 +56,13 @@ void Report::enter(std::string input, int &iFunction) {
     tmp.iLastEntry = iCurrentFunction;
 
     if (map_iFunctionVerbose.find(input) != map_iFunctionVerbose.end() &&
-	iProc == iProcReport)
+        iProc == iProcReport)
       tmp.iFunctionVerbose = get_FunctionVerbose(input);
 
-    else
+    else if (doInheritVerbose)
       tmp.iFunctionVerbose = iVerbose;
+    else
+      tmp.iFunctionVerbose = iDefaultVerbose;
 
     entries.push_back(tmp);
     nEntries++;
@@ -209,6 +211,14 @@ void Report::set_DefaultVerbose(int input) {
 }
 
 // -----------------------------------------------------------------------
+// Set the flag to have sub-functions inherit verbose levels
+// -----------------------------------------------------------------------
+
+void Report::set_doInheritVerbose(bool input) {
+  doInheritVerbose = input;
+}
+
+// -----------------------------------------------------------------------
 // Set the verbose level for the specified function
 // -----------------------------------------------------------------------
 
@@ -246,6 +256,14 @@ int Report::get_verbose() {
 
 int Report::get_DefaultVerbose() {
   return iDefaultVerbose;
+}
+
+// -----------------------------------------------------------------------
+// Get the flag to have sub-functions inherit verbose levels
+// -----------------------------------------------------------------------
+
+bool Report::get_doInheritVerbose() {
+  return doInheritVerbose;
 }
 
 // -----------------------------------------------------------------------

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <iostream>
 #include <chrono>
+#include <map>
 
 #include "aether.h"
 
@@ -52,11 +53,18 @@ void Report::enter(std::string input, int &iFunction) {
     tmp.timing_total = 0.0;
     tmp.iStringPosBefore = iOldStrLen;
     tmp.iLastEntry = iCurrentFunction;
+    if (map_iFunctionVerbose.find(input) != map_iFunctionVerbose.end()) {
+      tmp.iFunctionVerbose = get_FunctionVerbose(input);
+    } else {
+      tmp.iFunctionVerbose = iVerbose;
+    }
     entries.push_back(tmp);
     nEntries++;
     iEntry = nEntries - 1;
     iFunction = iEntry;
   }
+
+  iVerbose = entries[iEntry].iFunctionVerbose;
 
   // This was taken from
   // https://stackoverflow.com/questions/19555121/how-to-get-current-timestamp-in-milliseconds-since-1970-just-the-way-java-gets
@@ -108,6 +116,12 @@ void Report::exit(std::string input) {
     current_entry = current_entry.substr(0, entries[iEntry].iStringPosBefore);
     iCurrentFunction = entries[iEntry].iLastEntry;
     iLevel--;
+    if (iLevel > 0){
+      iVerbose = entries[iCurrentFunction].iFunctionVerbose;
+    }
+    else {
+      iVerbose = iDefaultVerbose;
+    }
   }
 }
 
@@ -176,6 +190,22 @@ void Report::set_verbose(int input) {
 }
 
 // -----------------------------------------------------------------------
+// Set the default "iVerbose" value that is passed in Aether.json
+// -----------------------------------------------------------------------
+
+void Report::set_DefaultVerbose(int input) {
+  iDefaultVerbose = input;
+}
+
+// -----------------------------------------------------------------------
+// Set the verbose level for the specified function
+// -----------------------------------------------------------------------
+
+void Report::set_FunctionVerbose(std::string input, int iFunctionVerbose) {
+  map_iFunctionVerbose[input] = iFunctionVerbose;
+}
+
+// -----------------------------------------------------------------------
 // Set the depth to report for timing at the end of the run
 // -----------------------------------------------------------------------
 
@@ -197,6 +227,22 @@ void Report::set_timing_percent(float input) {
 
 int Report::get_verbose() {
   return iVerbose;
+}
+
+// -----------------------------------------------------------------------
+// Get the default "iVerbose" that is passed in Aether.json
+// -----------------------------------------------------------------------
+
+int Report::get_DefaultVerbose() {
+  return iDefaultVerbose;
+}
+
+// -----------------------------------------------------------------------
+// Get the verbose level for the specified function in the code.
+// -----------------------------------------------------------------------
+
+int Report::get_FunctionVerbose(std::string input) {
+  return map_iFunctionVerbose[input];
 }
 
 // -----------------------------------------------------------------------

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -16,6 +16,7 @@ Report::Report() {
   current_entry = "";
   nEntries = 0;
   iVerbose = -2;
+  iProcReport = 0;
   divider = ">";
   divider_length = divider.length();
   // Set iLevel to -1, so that the call in main takes it to 0:
@@ -54,7 +55,8 @@ void Report::enter(std::string input, int &iFunction) {
     tmp.iStringPosBefore = iOldStrLen;
     tmp.iLastEntry = iCurrentFunction;
 
-    if (map_iFunctionVerbose.find(input) != map_iFunctionVerbose.end())
+    if (map_iFunctionVerbose.find(input) != map_iFunctionVerbose.end() &&
+	iProc == iProcReport)
       tmp.iFunctionVerbose = get_FunctionVerbose(input);
 
     else
@@ -188,6 +190,14 @@ int Report::test_verbose(int iLevel) {
 
 void Report::set_verbose(int input) {
   iVerbose = input;
+}
+
+// -----------------------------------------------------------------------
+// Set which processor will do the reporting
+// -----------------------------------------------------------------------
+
+void Report::set_iProc(int input) {
+  iProcReport = input;
 }
 
 // -----------------------------------------------------------------------

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -53,11 +53,13 @@ void Report::enter(std::string input, int &iFunction) {
     tmp.timing_total = 0.0;
     tmp.iStringPosBefore = iOldStrLen;
     tmp.iLastEntry = iCurrentFunction;
-    if (map_iFunctionVerbose.find(input) != map_iFunctionVerbose.end()) {
+
+    if (map_iFunctionVerbose.find(input) != map_iFunctionVerbose.end())
       tmp.iFunctionVerbose = get_FunctionVerbose(input);
-    } else {
+
+    else
       tmp.iFunctionVerbose = iVerbose;
-    }
+
     entries.push_back(tmp);
     nEntries++;
     iEntry = nEntries - 1;
@@ -116,12 +118,11 @@ void Report::exit(std::string input) {
     current_entry = current_entry.substr(0, entries[iEntry].iStringPosBefore);
     iCurrentFunction = entries[iEntry].iLastEntry;
     iLevel--;
-    if (iLevel > 0){
+
+    if (iLevel > 0)
       iVerbose = entries[iCurrentFunction].iFunctionVerbose;
-    }
-    else {
+    else
       iVerbose = iDefaultVerbose;
-    }
   }
 }
 
@@ -250,15 +251,16 @@ int Report::get_FunctionVerbose(std::string input) {
 // -----------------------------------------------------------------------
 
 void Report::student_checker_function_name(bool isStudent,
-					   std::string cStudentName,
-					   int iFunctionNumber,
-					   std::string cFunctionName) {
+                                           std::string cStudentName,
+                                           int iFunctionNumber,
+                                           std::string cFunctionName) {
   if (isStudent) {
     if (cFunctionName.length() > 1)
       print(-1, cStudentName + " found function " + cFunctionName);
     else
       std::cout << "> (" << iFunctionNumber << ")"
-		<< " What function is this " << cStudentName << "?\n";
+                << " What function is this " << cStudentName << "?\n";
   }
+
   return;
 }

--- a/tests/verbose/aether1.json
+++ b/tests/verbose/aether1.json
@@ -1,0 +1,23 @@
+
+{
+
+    "Debug" : {
+	"iVerbose" : 0,
+	"dt" : 10.0},
+
+    "GeoBlockSize" : {
+	"nLons" : 18,
+	"nLats" : 18,
+	"nAlts" : 50},
+
+    "Mysetting" : {
+	"setting1" : "this_is_an_example",
+	"setting2" : 42,
+	"setting3" : true},
+
+    "OmniwebFiles" : ["UA/inputs/omni_20110319.txt"],
+
+    "ElectrodynamicsFile" : "UA/inputs/b20110320n_omni.bin",
+
+    "DoCalcBulkIonTemp" : false
+}

--- a/tests/verbose/aether1.json
+++ b/tests/verbose/aether1.json
@@ -19,5 +19,7 @@
 
     "ElectrodynamicsFile" : "UA/inputs/b20110320n_omni.bin",
 
-    "DoCalcBulkIonTemp" : false
+    "DoCalcBulkIonTemp" : false,
+
+	"EndTime" : [2011, 3, 20, 1, 0, 0]
 }

--- a/tests/verbose/aether2.json
+++ b/tests/verbose/aether2.json
@@ -7,6 +7,7 @@
 		"advance" : 1,
 		"calc_aurora" : 2
 	},
+	"doInheritVerbose" : true,
 	"dt" : 10.0},
 
     "GeoBlockSize" : {

--- a/tests/verbose/aether2.json
+++ b/tests/verbose/aether2.json
@@ -1,0 +1,27 @@
+
+{
+
+    "Debug" : {
+	"iVerbose" : 0,
+	"iFunctionVerbose" : {
+		"advance" : 1,
+		"calc_aurora" : 2
+	},
+	"dt" : 10.0},
+
+    "GeoBlockSize" : {
+	"nLons" : 18,
+	"nLats" : 18,
+	"nAlts" : 50},
+
+    "Mysetting" : {
+	"setting1" : "this_is_an_example",
+	"setting2" : 42,
+	"setting3" : true},
+
+    "OmniwebFiles" : ["UA/inputs/omni_20110319.txt"],
+
+    "ElectrodynamicsFile" : "UA/inputs/b20110320n_omni.bin",
+
+    "DoCalcBulkIonTemp" : false
+}

--- a/tests/verbose/aether2.json
+++ b/tests/verbose/aether2.json
@@ -23,5 +23,7 @@
 
     "ElectrodynamicsFile" : "UA/inputs/b20110320n_omni.bin",
 
-    "DoCalcBulkIonTemp" : false
+    "DoCalcBulkIonTemp" : false,
+
+	"EndTime" : [2011, 3, 20, 1, 0, 0]
 }

--- a/tests/verbose/aether3.json
+++ b/tests/verbose/aether3.json
@@ -1,0 +1,27 @@
+
+{
+
+    "Debug" : {
+	"iVerbose" : 0,
+	"iFunctionVerbose" : {
+		"Chemistry::calc_chemistry" : 3,
+		"Grid::calc_sza" : 4
+	},
+	"dt" : 10.0},
+
+    "GeoBlockSize" : {
+	"nLons" : 18,
+	"nLats" : 18,
+	"nAlts" : 50},
+
+    "Mysetting" : {
+	"setting1" : "this_is_an_example",
+	"setting2" : 42,
+	"setting3" : true},
+
+    "OmniwebFiles" : ["UA/inputs/omni_20110319.txt"],
+
+    "ElectrodynamicsFile" : "UA/inputs/b20110320n_omni.bin",
+
+    "DoCalcBulkIonTemp" : false
+}

--- a/tests/verbose/aether3.json
+++ b/tests/verbose/aether3.json
@@ -23,5 +23,7 @@
 
     "ElectrodynamicsFile" : "UA/inputs/b20110320n_omni.bin",
 
-    "DoCalcBulkIonTemp" : false
+    "DoCalcBulkIonTemp" : false,
+
+	"EndTime" : [2011, 3, 20, 1, 0, 0]
 }

--- a/tests/verbose/run_test.sh
+++ b/tests/verbose/run_test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+rm -rf run.test1 run.test2 run.test3
+
+cp -R ../../share/run ./run.test1
+cd run.test1
+cp ../aether1.json ./aether.json
+./aether
+
+cp -R ../../share/run ./run.test2
+cd run.test2
+cp ../aether2.json ./aether.json
+./aether
+
+cp -R ../../share/run ./run.test3
+cd run.test3
+cp ../aether3.json ./aether.json
+./aether


### PR DESCRIPTION
# Description

Addresses #100 

The "iVerbose" command can be used under "Debug" in aether.json to set the overall verbose level in the code. Optionally, users can now also assign specific verbose levels to be used for certain functions by specifying the function names and the corresponding verbose levels using the "iFunctionVerbose" command as follows:

    "Debug" : {
    "iVerbose" : 0,
    "iFunctionVerbose" : {
        "func1" : 1,
        "func2" : 2},
    "dt" : 10.0
    }

When a sub-function is entered, the verbose level stays the same if the verbose level for that sub-function is not specified. When that sub-function exits, the verbose level will accordingly be set back to that of the function it is returning to.

## Type of change

- New feature: Added the ability to change the verbose level of the code on a function-by-function basis
- This change requires a documentation update

# How Has This Been Tested?

A tests/verbose directory contains a few aether.json test files and a script run_test.sh that tests the functionality of this.

## Test configuration

* Operating system: macOS Ventura 13.2
* Compiler, version number: Apple clang version 14.0.0
* Any details about your local setup that are relevant

# Checklist:

- [N/A] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [N/A] Add a note to ``CHANGELOG.md``, summarizing the changes