### PR TITLE
Added Calc_dt for cubesphere. 

### DIFF
--- a/include/grid.h
+++ b/include/grid.h
@@ -119,6 +119,10 @@ public:
   arma_cube dlat_center_scgc;
   arma_cube dlat_center_dist_scgc;
 
+  // dx dy for reference grid system
+  // Vector of dx dy of different altitudes
+  arma_vec drefx, drefy;
+
   std::vector<arma_cube> bfield_vcgc;
   arma_cube bfield_mag_scgc;
   std::vector<arma_cube> bfield_unit_vcgc;

--- a/include/neutrals.h
+++ b/include/neutrals.h
@@ -327,6 +327,14 @@ class Neutrals {
      \param grid The grid to define the neutrals on
    **/
   precision_t calc_dt(Grid grid);
+
+  /**********************************************************************
+     \brief Calculate dt (cell size / cMax) in each direction, and take min
+     \param dt returns the neutral time-step
+     \param grid The grid to define the neutrals on
+     This function is for cubesphere dt calculation only
+   **/
+  precision_t calc_dt_cubesphere(Grid grid);
   
   /**********************************************************************
      \brief Calculate the chapman integrals for the individual species

--- a/src/calc_neutral_derived.cpp
+++ b/src/calc_neutral_derived.cpp
@@ -336,6 +336,62 @@ precision_t Neutrals::calc_dt(Grid grid) {
   return dt;
 }
 
+precision_t Neutrals::calc_dt_cubesphere(Grid grid) {
+
+  std::string function = "Neutrals::calc_dt_cubesphere";
+  static int iFunction = -1;
+  report.enter(function, iFunction);
+
+  int iDir;
+
+  arma_vec dta(4);
+
+  // Get some dimensions
+  int64_t nAlts = grid.get_nAlts();
+  int64_t nXs = grid.get_nLons();
+  int64_t nYs = grid.get_nLats();
+  
+  // dtx dty for reference coordinate system
+  arma_cube dtx(size(cMax_vcgc[0]));
+  arma_cube dty(size(cMax_vcgc[0]));
+
+  // A dummy constant one matrix
+  arma_mat dummy_1(nXs, nYs, fill::ones);
+
+  // Loop through altitudes
+  for (int iAlt = 0; iAlt < nAlts; iAlt++) {
+    // Conver cMax to contravariant velocity first
+    arma_mat u1 = cMax_vcgc[0].slice(iAlt) % grid.A11_inv_scgc.slice(iAlt) + cMax_vcgc[1].slice(iAlt) % grid.A12_inv_scgc.slice(iAlt);
+    arma_mat u2 = cMax_vcgc[0].slice(iAlt) % grid.A21_inv_scgc.slice(iAlt) + cMax_vcgc[1].slice(iAlt) % grid.A22_inv_scgc.slice(iAlt);
+
+    dtx.slice(iAlt) = grid.drefx(iAlt)*dummy_1 / u1; 
+    dty.slice(iAlt) = grid.drefy(iAlt)*dummy_1 / u2; 
+  }
+
+  // simply some things, and just take the bulk value for now:
+  dta(0) = dtx.min();
+  dta(1) = dty.min();
+
+  if (input.get_nAltsGeo() > 1) {
+    arma_cube dtz = grid.dalt_center_scgc / cMax_vcgc[2];
+    dta(2) = dtz.min();
+  } else
+    dta(2) = 1e32;
+
+  dta(3) = 10.0;
+
+  dt = dta.min();
+
+  if (report.test_verbose(3))
+    std::cout << "dt for neutrals : " << dt << "\n";
+
+  if (report.test_verbose(4))
+    std::cout << " derived from dt(x, y, z, extra) : " << dta << "\n";
+
+  report.exit(function);
+  return dt;
+}
+
 //----------------------------------------------------------------------
 // Calculate the altitude integral of the different species for EUV
 // calculations.  Scale these to be the slant path through the

--- a/src/init_geo_grid.cpp
+++ b/src/init_geo_grid.cpp
@@ -855,12 +855,15 @@ void Grid::create_altitudes(Planets planet) {
 // ----------------------------------------------------------------------
 
 void Grid::correct_xy_grid(Planets planet) {
-
   std::string function = "Grid::correct_xy_grid";
   static int iFunction = -1;
   report.enter(function, iFunction);
 
   int64_t iAlt;
+
+  // initialize grid drefx drefy
+  drefx = arma_vec(nAlts); 
+  drefy = arma_vec(nAlts);
 
   // Planet.get_radius() takes in latitude
   // but at current stage is unimplemented
@@ -889,6 +892,13 @@ void Grid::correct_xy_grid(Planets planet) {
     g21_upper_scgc.slice(iAlt) /= R * R;
     g22_upper_scgc.slice(iAlt) /= R * R;
     sqrt_g_scgc.slice(iAlt) *= R * R;
+
+    // Addition: Get a copy of dx dy
+    arma_mat curr_refx = refx_scgc.slice(iAlt);
+    arma_mat curr_refy = refy_scgc.slice(iAlt);
+
+    drefx(iAlt) = curr_refx(1, 0) - curr_refx(0, 0);
+    drefy(iAlt) = curr_refy(0, 1) - curr_refy(0, 0);
 
     refx_Left.slice(iAlt) *= R;
     refy_Left.slice(iAlt) *= R;

--- a/src/main/main_test_coord.cpp
+++ b/src/main/main_test_coord.cpp
@@ -300,7 +300,6 @@ int main() {
   bool DidWork = true;
 
   Times time;
-  Report report;
 
   // Define the function and report:
   std::string function = "main";
@@ -310,21 +309,21 @@ int main() {
   try {
   
     // Create inputs (reading the input file):
-    Inputs input(time, report);
+    input = Inputs(time);
     if (!input.is_ok())
       throw std::string("input initialization failed!");
     
-    Quadtree quadtree(input, report);
+    Quadtree quadtree;
     if (!quadtree.is_ok())
       throw std::string("quadtree initialization failed!");
     
     // Initialize MPI and parallel aspects of the code:
-    DidWork = init_parallel(input, quadtree, report);
+    DidWork = init_parallel(quadtree);
     if (!DidWork)
       throw std::string("init_parallel failed!");
     
     // Initialize the planet:
-    Planets planet(input, report);
+    Planets planet;
     MPI_Barrier(aether_comm);
     if (!planet.is_ok())
       throw std::string("planet initialization failed!");
@@ -334,7 +333,7 @@ int main() {
 	           input.get_nLatsGeo(),
 	           input.get_nAltsGeo(),
 	           nGeoGhosts);
-    DidWork = gGrid.init_geo_grid(quadtree, planet, input, report);
+    DidWork = gGrid.init_geo_grid(quadtree, planet);
 
     // First check whether the initialization uses exactly 6 processes. 
     // The exactly 6 requirements is due to the checking of the range of reference coordinate system
@@ -347,7 +346,7 @@ int main() {
     // Coordinate Generation Testing
     {
       // Set tolerance limit 
-      precision_t tol = 1e-6;
+      precision_t tol = 1e-5;
 
       // Get number of ghost cells
       int nGCs_lcl = gGrid.get_nGCs();


### PR DESCRIPTION
# Description
Added a `calc_dt_cubesphere()` for cubesphere. dtx and dty are based on contravariant (reference) speed of sound. 
Also updated `main_test_coord()` with current version of Aether. 

I have also added two arma_vec `drefx` and `drefy`, with the rows representing altitudes, as a construct to feed into `calc_dt_cubesphere()`. xy reference grid should equidistant, so we are not getting a full matrix of dx and dy. 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)

# How Has This Been Tested?
I have tested `drefx` and `drefy` as they vary by altitude and is (almost) the same number (since they should be the same as the grid resolution is square and equidistant). 

I have not tested `calc_dt_cubesphere()`; it needs to be incorporate into the cubesphere workflow since this requires further changes in code. 

## Test configuration
* Operating system: Pop!_OS 21.10 (Linux 5.18.10)
* Compiler, version number: gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0

# Checklist:

- [N/A] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [N/A] Add a note to ``CHANGELOG.md``, summarizing the changes
