### PR TITLE
BUG: Incorportated horizontal cubesphere dt calculation

### DIFF
--- a/include/neutrals.h
+++ b/include/neutrals.h
@@ -341,14 +341,6 @@ class Neutrals {
   precision_t calc_dt(Grid grid);
 
   /**********************************************************************
-     \brief Calculate dt (cell size / cMax) in each direction, and take min
-     \param dt returns the neutral time-step
-     \param grid The grid to define the neutrals on
-     This function is for cubesphere dt calculation only
-   **/
-  precision_t calc_dt_cubesphere(Grid grid);
-  
-  /**********************************************************************
      \brief Calculate the chapman integrals for the individual species
      \param grid The grid to define the neutrals on
    **/

--- a/src/calc_neutral_derived.cpp
+++ b/src/calc_neutral_derived.cpp
@@ -343,68 +343,43 @@ precision_t Neutrals::calc_dt(Grid grid) {
   arma_vec dta(4);
 
   // simply some things, and just take the bulk value for now:
-  arma_cube dtx = grid.dlon_center_dist_scgc / cMax_vcgc[0];
-  dta(0) = dtx.min();
+  if (input.get_is_cubesphere()) {
+    // Get some dimensions
+    int64_t nAlts = grid.get_nAlts();
+    int64_t nXs = grid.get_nLons();
+    int64_t nYs = grid.get_nLats();
+    
+    // dtx dty for reference coordinate system
+    arma_cube dtx(size(cMax_vcgc[0]));
+    arma_cube dty(size(cMax_vcgc[0]));
 
-  arma_cube dty = grid.dlat_center_dist_scgc / cMax_vcgc[1];
-  dta(1) = dty.min();
+    // A dummy constant one matrix
+    arma_mat dummy_1(nXs, nYs, fill::ones);
 
-  if (input.get_nAltsGeo() > 1) {
-    arma_cube dtz = grid.dalt_center_scgc / cMax_vcgc[2];
-    dta(2) = dtz.min();
-  } else
-    dta(2) = 1e32;
+    // Loop through altitudes
+    for (int iAlt = 0; iAlt < nAlts; iAlt++) {
+      // Conver cMax to contravariant velocity first
+      arma_mat u1 = cMax_vcgc[0].slice(iAlt) % grid.A11_inv_scgc.slice(iAlt) 
+        + cMax_vcgc[1].slice(iAlt) % grid.A12_inv_scgc.slice(iAlt);
+      arma_mat u2 = cMax_vcgc[0].slice(iAlt) % grid.A21_inv_scgc.slice(iAlt) 
+        + cMax_vcgc[1].slice(iAlt) % grid.A22_inv_scgc.slice(iAlt);
 
-  dta(3) = 10.0;
+      // Extract a scalar dx and divide by contravariant velocity
+      dtx.slice(iAlt) = grid.drefx(iAlt)*dummy_1 / u1; 
+      dty.slice(iAlt) = grid.drefy(iAlt)*dummy_1 / u2; 
+    }
 
-  dt = dta.min();
+    // simply some things, and just take the bulk value for now:
+    dta(0) = dtx.min();
+    dta(1) = dty.min();
+  } else {
+    arma_cube dtx = grid.dlon_center_dist_scgc / cMax_vcgc[0];
+    dta(0) = dtx.min();
 
-  if (report.test_verbose(3))
-    std::cout << "dt for neutrals : " << dt << "\n";
-
-  if (report.test_verbose(4))
-    std::cout << " derived from dt(x, y, z, extra) : " << dta << "\n";
-
-  report.exit(function);
-  return dt;
-}
-
-precision_t Neutrals::calc_dt_cubesphere(Grid grid) {
-
-  std::string function = "Neutrals::calc_dt_cubesphere";
-  static int iFunction = -1;
-  report.enter(function, iFunction);
-
-  int iDir;
-
-  arma_vec dta(4);
-
-  // Get some dimensions
-  int64_t nAlts = grid.get_nAlts();
-  int64_t nXs = grid.get_nLons();
-  int64_t nYs = grid.get_nLats();
-  
-  // dtx dty for reference coordinate system
-  arma_cube dtx(size(cMax_vcgc[0]));
-  arma_cube dty(size(cMax_vcgc[0]));
-
-  // A dummy constant one matrix
-  arma_mat dummy_1(nXs, nYs, fill::ones);
-
-  // Loop through altitudes
-  for (int iAlt = 0; iAlt < nAlts; iAlt++) {
-    // Conver cMax to contravariant velocity first
-    arma_mat u1 = cMax_vcgc[0].slice(iAlt) % grid.A11_inv_scgc.slice(iAlt) + cMax_vcgc[1].slice(iAlt) % grid.A12_inv_scgc.slice(iAlt);
-    arma_mat u2 = cMax_vcgc[0].slice(iAlt) % grid.A21_inv_scgc.slice(iAlt) + cMax_vcgc[1].slice(iAlt) % grid.A22_inv_scgc.slice(iAlt);
-
-    dtx.slice(iAlt) = grid.drefx(iAlt)*dummy_1 / u1; 
-    dty.slice(iAlt) = grid.drefy(iAlt)*dummy_1 / u2; 
+    arma_cube dty = grid.dlat_center_dist_scgc / cMax_vcgc[1];
+    dta(1) = dty.min();
   }
-
-  // simply some things, and just take the bulk value for now:
-  dta(0) = dtx.min();
-  dta(1) = dty.min();
-
+  
   if (input.get_nAltsGeo() > 1) {
     arma_cube dtz = grid.dalt_center_scgc / cMax_vcgc[2];
     dta(2) = dtz.min();


### PR DESCRIPTION
# Description
Same as #139. However, instead of separate function, it is incorporated into calc_dt(). 

## Type of change


- Bug fix (non-breaking change that fixes an issue)


# How Has This Been Tested?

I have not tested `calc_dt_cubesphere()`; it needs to be incorporated into the cubesphere workflow since this requires further changes in code. 

## Test configuration
* Operating system: Pop!_OS 21.10 (Linux 5.18.10)
* Compiler, version number: gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0

# Checklist:


- [N/A] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [N/A] Add a note to ``CHANGELOG.md``, summarizing the changes