### PR TITLE
Change output variable names and vastly improve settings checks

### DIFF
--- a/include/inputs.h
+++ b/include/inputs.h
@@ -121,16 +121,37 @@ public:
   std::vector<std::string> get_satellite_names();
   std::vector<precision_t> get_satellite_dts();
   
-  std::string get_settings_str(std::string key1);
-  std::string get_settings_str(std::string key1, std::string key2);
-  int get_settings(std::string key1, std::string key2);
-  bool check_settings(std::string key1, std::string key2);
+  // General get_setting functions with error checks:
+  std::string get_setting_str(std::string key1);
+  std::string get_setting_str(std::string key1, std::string key2);
+  std::string get_setting_str(std::string key1,
+                              std::string key2,
+                              std::string key3);
+
+  json get_setting_json(std::string key1);
+  json get_setting_json(std::string key1, std::string key2);
+
+  bool get_setting_bool(std::string key1);
+  bool get_setting_bool(std::string key1, std::string key2);
+  bool get_setting_bool(std::string key1, std::string key2, std::string key3);
+
+  precision_t get_setting_float(std::string key1);
+  precision_t get_setting_float(std::string key1, std::string key2);
+
+  int64_t get_setting_int(std::string key1);
+  int64_t get_setting_int(std::string key1, std::string key2);
+
+  std::vector<int> get_setting_intarr(std::string key1);
+  std::vector<int> get_setting_timearr(std::string key1);
+
+  // Check settings functions:
   bool check_settings(std::string key1);
-  std::string check_settings_str(std::string key1, std::string key2);
+  bool check_settings(std::string key1, std::string key2);
+
   std::string check_settings_str(std::string key1);
+  std::string check_settings_str(std::string key1, std::string key2);
+
   precision_t check_settings_pt(std::string key1, std::string key2);
-  std::vector<int> get_settings_timearr(std::string key1);
-  std::vector<int> get_settings_intarr(std::string key1);
   
   /**********************************************************************
      \brief Check to see if internal state of class is ok
@@ -181,7 +202,7 @@ private:
   int updated_seed;
   
   /// An internal variable to hold the state of the class
-  bool IsOk;
+  bool isOk;
 
   std::vector<std::string> missing_settings;
 };

--- a/src/inputs.cpp
+++ b/src/inputs.cpp
@@ -62,9 +62,9 @@ Inputs::Inputs(Times &time) {
 
   // ------------------------------------------------
   // Now read the input file:
-  IsOk = read_inputs_json(time);
+  isOk = read_inputs_json(time);
 
-  if (!IsOk && iProc == 0)
+  if (!isOk && iProc == 0)
     std::cout << "Error in reading input file!\n";
 }
 
@@ -73,177 +73,21 @@ Inputs::Inputs(Times &time) {
 // -----------------------------------------------------------------------
 
 bool Inputs::write_restart() {
-  bool DidWork = true;
-
+  bool didWork = true;
   if (iProc == 0) {
-    std::string filename = check_settings_str("Restart", "OutDir");
+    std::string filename = get_setting_str("Restart", "OutDir");
     filename = filename + "/settings.json";
-    DidWork = write_json(filename, settings);
+    didWork = write_json(filename, settings);
   }
-
-  DidWork = sync_across_all_procs(DidWork);
-  return DidWork;
+  didWork = sync_across_all_procs(didWork);
+  return didWork;
 }
 
-// -----------------------------------------------------------------------
-// Return log file name
-// -----------------------------------------------------------------------
-
-std::string Inputs::get_logfile() {
-  std::string logfile = check_settings_str("Logfile", "name");
-
-  if (nMembers > 1)
-    logfile = add_cmember(logfile);
-
-  return logfile;
-}
 
 // -----------------------------------------------------------------------
-// Return how oftern to write log file
-// -----------------------------------------------------------------------
-
-precision_t Inputs::get_logfile_dt() {
-  precision_t setting = -1;
-
-  if (check_settings("Logfile", "dt"))
-    setting = settings.at("Logfile").at("dt");
-
-  return setting;
-}
-
-// -----------------------------------------------------------------------
-// Return whether to append or rewrite
-// -----------------------------------------------------------------------
-
-bool Inputs::get_logfile_append() {
-  return settings.at("Logfile").at("append");
-}
-
-// -----------------------------------------------------------------------
-// Return the name of specified variables as a vector
-// -----------------------------------------------------------------------
-
-std::vector<std::string> Inputs::get_species_vector() {
-  std::vector<std::string> species;
-  const json &json_species = settings.at("Logfile").at("species");
-
-  for (size_t iOutput = 0; iOutput < json_species.size(); iOutput++)
-    species.push_back(json_species.at(iOutput));
-
-  return species;
-}
-
-// -----------------------------------------------------------------------
-// Return the name of satellite files as a vector
-// -----------------------------------------------------------------------
-
-std::vector<std::string> Inputs::get_satellite_files() {
-  std::vector<std::string> files;
-  const json &json_files = settings["Satellites"]["files"];
-
-  for (size_t i = 0; i < json_files.size(); ++i)
-    files.push_back(json_files.at(i));
-
-  return files;
-}
-
-// -----------------------------------------------------------------------
-// Return the output file names of satellites as a vector
-// -----------------------------------------------------------------------
-
-std::vector<std::string> Inputs::get_satellite_names() {
-  std::vector<std::string> names;
-  const json &json_names = settings["Satellites"]["names"];
-
-  for (size_t i = 0; i < json_names.size(); ++i)
-    names.push_back(json_names.at(i));
-
-  return names;
-}
-
-// -----------------------------------------------------------------------
-// Return how oftern to write log file for satellites as a vector
-// -----------------------------------------------------------------------
-
-std::vector<precision_t> Inputs::get_satellite_dts() {
-  std::vector<precision_t> dts;
-  const json &json_dts = settings["Satellites"]["dts"];
-
-  for (size_t i = 0; i < json_dts.size(); ++i)
-    dts.push_back(json_dts.at(i));
-
-  return dts;
-}
-
-// -----------------------------------------------------------------------
-// Return value of a key in the json formatted inputs
-// -----------------------------------------------------------------------
-
-//set up dummy values for settings that aren't set
-
-std::vector<int> Inputs::get_settings_intarr(std::string key1) {
-  std::vector<int> value;
-
-  if (settings.find(key1) != settings.end()) {
-    int nPts = settings.at(key1).size();
-
-    for (int i = 0; i < nPts; i++)
-      value.push_back(settings.at(key1).at(i));
-  } else
-    IsOk = false;
-
-  return value;
-}
-
-std::vector<int> Inputs::get_settings_timearr(std::string key1) {
-  int nPtsTime = 7;
-  std::vector<int> outarr(nPtsTime, 0);
-  std::vector<int> timearr = get_settings_intarr(key1);
-
-  int nPts = timearr.size();
-
-  if (nPts > nPtsTime)
-    nPts = nPtsTime;
-
-  for (int i = 0; i < nPts; i++)
-    outarr[i] = timearr[i];
-
-  return outarr;
-}
-
-std::string Inputs::get_settings_str(std::string key1) {
-  std::string value = "unknown";
-
-  if (settings.find(key1) != settings.end())
-    value = settings.at(key1);
-
-  return value;
-}
-
-std::string Inputs::get_settings_str(std::string key1,
-                                     std::string key2) {
-  std::string value = "unknown";
-
-  if (settings.find(key1) != settings.end())
-    if (settings.at(key1).find(key2) != settings.at(key1).end())
-      value = settings.at(key1).at(key2);
-
-  return value;
-}
-
-int Inputs::get_settings(std::string key1,
-                         std::string key2) {
-  int value = -1;
-
-  if (settings.find(key1) != settings.end())
-    if (settings.at(key1).find(key2) != settings.at(key1).end())
-      value = settings.at(key1).at(key2);
-
-  return value;
-}
-
-// -----------------------------------------------------------------------
-// Check for missing settings
+// General check functions to see if keys exist:
+// check settings and throw invalid_argument error 
+// if the setting doesn't exist
 // -----------------------------------------------------------------------
 
 //dummy values, to use if the settings are not set
@@ -251,71 +95,274 @@ int dummy_int = -1;
 float dummy_float = -1;
 std::string dummy_string = "unknown";
 
-//check settings and throw invalid_argument error if the setting doesn't exist
+// -----------------------------------------------------------------------
+// 2 keys:
+
 bool Inputs::check_settings(std::string key1,
                             std::string key2) {
-
   if (report.test_verbose(1))
     std::cout << "checking setting : "
               << key1 << " and "
               << key2 << "\n";
-
   //try to find the keys first
   if (settings.find(key1) != settings.end()) {
     if (settings.at(key1).find(key2) != settings.at(key1).end())
-      return true;
-  }
+      isOk = true;
+  } else
+    //if we haven't found the keys print a message & set IsOk to false
+    isOk = false;
 
-  //if we haven't found the keys print a message & set IsOk to false
-  IsOk = false;
-
-  if (!IsOk)
+  if (!isOk) {
+    report.error("Error in setting : " + key1 + " : " + key2);
     std::cout << "Missing setting called! [" << key1 << ", " << key2 << "]\n";
-
-  return false;
+  }
+  return isOk;
 }
+
+// -----------------------------------------------------------------------
+// 1 key:
 
 bool Inputs::check_settings(std::string key1) {
-
   if (report.test_verbose(1))
     std::cout << "checking setting : " << key1 << "\n";
-
   // try to find the keys first
   if (settings.find(key1) != settings.end())
-    return true;
-
-  //if we haven't found the key print a message & set IsOk to false
-  IsOk = false;
+    isOk = true;
+  else
+    //if we haven't found the key print a message & set IsOk to false
+    isOk = false;
 
   //perturb is non-essential, otherwise print error message
-  if (!IsOk && key1 != "Perturb")
+  if (!isOk && key1 != "Perturb") {
+    report.error("Error in setting : " + key1);
     std::cout << "Missing setting called! [" << key1 << "]\n";
-
-  return false;
+  }
+  return isOk;
 }
+
+// -----------------------------------------------------------------------
+// Functions that check keys and return values:
+// -----------------------------------------------------------------------
+
+// -----------------------------------------------------------------------
+// a general int vector
+
+std::vector<int> Inputs::get_setting_intarr(std::string key1) {
+  std::vector<int> value;
+  if (check_settings(key1)) {
+    int nPts = settings.at(key1).size();
+    isOk = true;
+    for (int i = 0; i < nPts; i++)
+      value.push_back(settings.at(key1).at(i));
+  } else
+    isOk = false;
+  return value;
+}
+
+// -----------------------------------------------------------------------
+// A specific length int vector
+
+std::vector<int> Inputs::get_setting_timearr(std::string key1) {
+  int nPtsTime = 7;
+  std::vector<int> outarr(nPtsTime, 0);
+  std::vector<int> timearr = get_setting_intarr(key1);
+  if (isOk) {
+    int nPts = timearr.size();
+    if (nPts > nPtsTime)
+      nPts = nPtsTime;
+    for (int i = 0; i < nPts; i++)
+      outarr[i] = timearr[i];
+  }
+  return outarr;
+}
+
+// -----------------------------------------------------------------------
+// a string with 1 key:
+
+std::string Inputs::get_setting_str(std::string key1) {
+  std::string value = "unknown";
+  if (check_settings(key1))
+    value = settings.at(key1);
+  return value;
+}
+
+// -----------------------------------------------------------------------
+// a string with 2 keys:
+
+std::string Inputs::get_setting_str(std::string key1,
+                                    std::string key2) {
+  std::string value = "unknown";
+  if (check_settings(key1, key2))
+    value = settings.at(key1).at(key2);
+  return value;
+}
+
+// -----------------------------------------------------------------------
+// a string with 3 keys:
+
+std::string Inputs::get_setting_str(std::string key1,
+                                    std::string key2,
+                                    std::string key3) {
+  std::string value = "unknown";
+  isOk = false;
+  if (settings.find(key1) != settings.end())
+    if (settings.at(key1).find(key2) != settings.at(key1).end())
+      if (settings.at(key1).at(key2).find(key3) != 
+          settings.at(key1).at(key2).end()) {
+        value = settings.at(key1).at(key2).at(key3);
+        isOk = true;
+      }
+  if (!isOk)
+    report.error("Error in setting : " + key1 + " : " + key2 + " : " + key3);
+  return value;
+}
+
+// -----------------------------------------------------------------------
+// an int with 1 key:
+
+int64_t Inputs::get_setting_int(std::string key1) {
+  int64_t value = LONG_MIN;
+  if (check_settings(key1))
+    value = settings.at(key1);
+  return value;
+}
+
+// -----------------------------------------------------------------------
+// an int with 2 keys:
+
+int64_t Inputs::get_setting_int(std::string key1,
+                                std::string key2) {
+  int64_t value = LONG_MIN;
+  if (check_settings(key1, key2))
+    value = settings.at(key1).at(key2);
+  return value;
+}
+
+// -----------------------------------------------------------------------
+// a bool with 1 key:
+
+bool Inputs::get_setting_bool(std::string key1) {
+  bool value = false;
+  if (check_settings(key1))
+    value = settings.at(key1);
+  return value;
+}
+
+// -----------------------------------------------------------------------
+// a bool with 2 keys:
+
+bool Inputs::get_setting_bool(std::string key1,
+                              std::string key2) {
+  bool value = false;
+  if (check_settings(key1, key2))
+    value = settings.at(key1).at(key2);
+  return value;
+}
+
+// -----------------------------------------------------------------------
+// a bool with 3 keys:
+
+bool Inputs::get_setting_bool(std::string key1,
+                              std::string key2,
+                              std::string key3) {
+  bool value = false;
+  isOk = false;
+  if (settings.find(key1) != settings.end())
+    if (settings.at(key1).find(key2) != settings.at(key1).end())
+      if (settings.at(key1).at(key2).find(key3) != 
+          settings.at(key1).at(key2).end()) {
+        value = settings.at(key1).at(key2).at(key3);
+        isOk = true;
+      }
+  if (!isOk)
+    report.error("Error in setting : " + key1 + " : " + key2 + " : " + key3);
+  return value;
+}
+
+// -----------------------------------------------------------------------
+// a float with 1 key:
+
+precision_t Inputs::get_setting_float(std::string key1) {
+  precision_t value = std::numeric_limits<precision_t>::lowest();
+  if (check_settings(key1))
+    value = settings.at(key1);
+  return value;
+}
+
+// -----------------------------------------------------------------------
+// a float with 2 key:
+
+precision_t Inputs::get_setting_float(std::string key1,
+                                      std::string key2) {
+  precision_t value = std::numeric_limits<precision_t>::lowest();
+  if (check_settings(key1, key2))
+      value = settings.at(key1).at(key2);
+  return value;
+}
+
+// -----------------------------------------------------------------------
+// a json with 1 key:
+
+json Inputs::get_setting_json(std::string key1) {
+  json value;
+  if (settings.find(key1) != settings.end())
+    value = settings.at(key1);
+  else {
+    isOk = false;
+    report.error("Error in setting : " + key1);
+  }
+  return value;
+}
+
+// -----------------------------------------------------------------------
+// a json with 2 keys:
+
+json Inputs::get_setting_json(std::string key1,
+                              std::string key2) {
+  json value;
+  if (settings.find(key1) != settings.end())
+    if (settings.at(key1).find(key2) != settings.at(key1).end())
+      value = settings.at(key1).at(key2);
+    else {
+      isOk = false;
+      report.error("Error in setting : " + key1 + " : " + key2);
+    }
+  else {
+    isOk = false;
+    report.error("Error in setting : " + key1);
+  }
+  return value;
+}
+
+// -----------------------------------------------------------------------
+// a string with 2 keys:
 
 std::string Inputs::check_settings_str(std::string key1,
                                        std::string key2) {
   if (check_settings(key1, key2))
     return settings.at(key1).at(key2);
-
   return dummy_string;
 }
 
+// -----------------------------------------------------------------------
+// a string with 1 key:
+
 std::string Inputs::check_settings_str(std::string key) {
-  if (get_settings_str(key) == dummy_string) {
-    IsOk = false;
+  if (get_setting_str(key) == dummy_string) {
+    isOk = false;
     return dummy_string;
   }
-
   return settings[key];
 }
+
+// -----------------------------------------------------------------------
+// a float with 2 keys:
 
 precision_t Inputs::check_settings_pt(std::string key1,
                                       std::string key2) {
   if (check_settings(key1, key2))
     return settings.at(key1).at(key2);
-
+  isOk = false;
   return dummy_float;
 }
 
@@ -328,8 +375,8 @@ Inputs::grid_input_struct Inputs::get_grid_inputs() {
   geo_grid_input.alt_file = check_settings_str("GeoGrid", "AltFile");
 
   if (check_settings("GeoGrid", "IsUniformAlt")) {
-    bool reality = settings.at("GeoGrid").at("IsUniformAlt");
-    geo_grid_input.IsUniformAlt = settings.at("GeoGrid").at("IsUniformAlt");
+    bool reality = get_setting_bool("GeoGrid", "IsUniformAlt");
+    geo_grid_input.IsUniformAlt = get_setting_bool("GeoGrid", "IsUniformAlt");
   } else
     geo_grid_input.IsUniformAlt = true;
 
@@ -356,14 +403,193 @@ Inputs::grid_input_struct Inputs::get_grid_inputs() {
 }
 
 // -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
+// More complicated get functions:
+// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
+
+// This is needed, because we may want to check for verbose specifically
+// in a given json and not the normal settings json:
+
+bool Inputs::set_verbose(json in) {
+  bool didWork = true;
+  int iVerbose = -1;
+  // Want to set verbose level ASAP:
+  if (in.contains("Debug")) {
+    if (in.at("Debug").contains("iVerbose")) {
+      iVerbose = in.at("Debug").at("iVerbose");
+      if (in.at("Debug").contains("iProc")) {
+        if (iProc != in.at("Debug").at("iProc"))
+          iVerbose = -1;
+      }
+    } else
+      didWork = false;
+  } else
+    didWork = false;
+  if (iVerbose > 0) {
+    std::cout << "Setting iVerbose : " << iVerbose << "\n";
+    report.set_verbose(iVerbose);
+  }
+  return didWork;
+}
+
+// -----------------------------------------------------------------------
+// Return total number of OMNIWeb files to read
+// -----------------------------------------------------------------------
+
+int Inputs::get_number_of_omniweb_files() {
+  if (settings.find("OmniwebFiles") != settings.end())
+    return settings.at("OmniwebFiles").size();
+  isOk = false;
+  return dummy_int;
+}
+
+// -----------------------------------------------------------------------
+// Return OMNIWeb file names as a vector
+// -----------------------------------------------------------------------
+
+std::vector<std::string> Inputs::get_omniweb_files() {
+  std::vector<std::string> omniweb_files;
+  int nFiles = get_number_of_omniweb_files();
+  for (int i = 0; i < nFiles; i++)
+    omniweb_files.push_back(settings.at("OmniwebFiles").at(i));
+  return omniweb_files;
+}
+
+// -----------------------------------------------------------------------
+// Return how often to output a given output type
+// -----------------------------------------------------------------------
+
+precision_t Inputs::get_dt_output(int iOutput) {
+  precision_t value = 0.0;
+  int nOutputs = settings.at("Outputs").at("type").size();
+
+  if (iOutput < nOutputs)
+    value = settings.at("Outputs").at("dt").at(iOutput);
+
+  return value;
+}
+
+// -----------------------------------------------------------------------
+// Return the output type
+// -----------------------------------------------------------------------
+
+std::string Inputs::get_type_output(int iOutput) {
+  std::string value = "unknown";
+  int nOutputs = settings.at("Outputs").at("type").size();
+
+  if (iOutput < nOutputs)
+    value = settings.at("Outputs").at("type").at(iOutput);
+
+  return value;
+}
+
+// -----------------------------------------------------------------------
+// Set random number seed
+// -----------------------------------------------------------------------
+
+void Inputs::set_seed(int seed) {
+  settings["Seed"] = seed;
+  updated_seed = seed;
+}
+
+// -----------------------------------------------------------------------
+// Return random number seed that has been updated
+// -----------------------------------------------------------------------
+
+int Inputs::get_updated_seed() {
+  std::default_random_engine get_random(updated_seed);
+  updated_seed = get_random();
+  return updated_seed;
+}
+
+// -----------------------------------------------------------------------
+// Return log file name
+// -----------------------------------------------------------------------
+
+std::string Inputs::get_logfile() {
+  std::string logfile = get_setting_str("Logfile", "name");
+  if (nMembers > 1)
+    logfile = add_cmember(logfile);
+  return logfile;
+}
+
+// -----------------------------------------------------------------------
+// Return the name of specified variables as a vector
+// -----------------------------------------------------------------------
+
+std::vector<std::string> Inputs::get_species_vector() {
+  std::vector<std::string> species;
+  const json &json_species = get_setting_json("Logfile", "species");
+  for (size_t iOutput = 0; iOutput < json_species.size(); iOutput++)
+    species.push_back(json_species.at(iOutput));
+  return species;
+}
+
+// -----------------------------------------------------------------------
+// Return the name of satellite files as a vector
+// -----------------------------------------------------------------------
+
+std::vector<std::string> Inputs::get_satellite_files() {
+  std::vector<std::string> files;
+  const json &json_files = get_setting_json("Satellites", "files");
+  for (size_t i = 0; i < json_files.size(); ++i)
+    files.push_back(json_files.at(i));
+  return files;
+}
+
+// -----------------------------------------------------------------------
+// Return the output file names of satellites as a vector
+// -----------------------------------------------------------------------
+
+std::vector<std::string> Inputs::get_satellite_names() {
+  std::vector<std::string> names;
+  const json &json_names = get_setting_json("Satellites", "names");
+  for (size_t i = 0; i < json_names.size(); ++i)
+    names.push_back(json_names.at(i));
+  return names;
+}
+
+// -----------------------------------------------------------------------
+// Return how oftern to write log file for satellites as a vector
+// -----------------------------------------------------------------------
+
+std::vector<precision_t> Inputs::get_satellite_dts() {
+  std::vector<precision_t> dts;
+  const json &json_dts = get_setting_json("Satellites", "dts");
+  for (size_t i = 0; i < json_dts.size(); ++i)
+    dts.push_back(json_dts.at(i));
+  return dts;
+}
+
+// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
+// Extremely simple get functions:
+// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
+
+// -----------------------------------------------------------------------
+// Return how oftern to write log file
+// -----------------------------------------------------------------------
+
+precision_t Inputs::get_logfile_dt() {
+  return get_setting_float("Logfile", "dt");
+}
+
+// -----------------------------------------------------------------------
+// Return whether to append or rewrite
+// -----------------------------------------------------------------------
+
+bool Inputs::get_logfile_append() {
+  return get_setting_bool("Logfile", "append");
+}
+
+// -----------------------------------------------------------------------
 // Return whether user is student
 // -----------------------------------------------------------------------
 
 bool Inputs::get_is_student() {
-  if (check_settings("Student", "is"))
-    return settings.at("Student").at("is");
-
-  return false;
+  return get_setting_bool("Student", "is");
 }
 
 // -----------------------------------------------------------------------
@@ -379,10 +605,7 @@ std::string Inputs::get_student_name() {
 // -----------------------------------------------------------------------
 
 bool Inputs::get_is_cubesphere() {
-  if (check_settings("CubeSphere", "is"))
-    return settings.at("CubeSphere").at("is");
-
-  return false;
+  return get_setting_bool("CubeSphere", "is");
 }
 
 // -----------------------------------------------------------------------
@@ -390,10 +613,7 @@ bool Inputs::get_is_cubesphere() {
 // -----------------------------------------------------------------------
 
 bool Inputs::get_do_restart() {
-  if (check_settings("Restart", "do"))
-    return settings.at("Restart").at("do");
-
-  return false;
+  return get_setting_bool("Restart", "do");
 }
 
 // -----------------------------------------------------------------------
@@ -401,7 +621,7 @@ bool Inputs::get_do_restart() {
 // -----------------------------------------------------------------------
 
 bool Inputs::get_NO_cooling() {
-  return settings["Sources"]["Neutrals"]["NO_cool"];
+  return get_setting_bool("Sources", "Neutrals", "NO_cool");
 }
 
 // -----------------------------------------------------------------------
@@ -409,7 +629,7 @@ bool Inputs::get_NO_cooling() {
 // -----------------------------------------------------------------------
 
 bool Inputs::get_O_cooling() {
-  return settings["Sources"]["Neutrals"]["O_cool"];
+  return get_setting_bool("Sources", "Neutrals", "O_cool");
 }
 
 // -----------------------------------------------------------------------
@@ -417,7 +637,7 @@ bool Inputs::get_O_cooling() {
 // -----------------------------------------------------------------------
 
 bool Inputs::get_cent_acc() {
-  return settings["Sources"]["Grid"]["Cent_acc"];
+  return get_setting_bool("Sources", "Grid", "Cent_acc");
 }
 
 // -----------------------------------------------------------------------
@@ -457,7 +677,7 @@ std::string Inputs::get_bfield_type() {
 // -----------------------------------------------------------------------
 
 bool Inputs::get_euv_douse() {
-  return settings.at("Euv").at("doUse");
+  return get_setting_bool("Euv", "doUse");
 }
 
 // -----------------------------------------------------------------------
@@ -501,7 +721,7 @@ std::string Inputs::get_electrodynamics_dir() {
 // -----------------------------------------------------------------------
 
 std::string Inputs::get_potential_model() {
-  return check_settings_str("Electrodynamics", "Potential");
+  return mklower(check_settings_str("Electrodynamics", "Potential"));
 }
 
 // -----------------------------------------------------------------------
@@ -509,7 +729,7 @@ std::string Inputs::get_potential_model() {
 // -----------------------------------------------------------------------
 
 std::string Inputs::get_diffuse_auroral_model() {
-  return check_settings_str("Electrodynamics", "DiffuseAurora");
+  return mklower(check_settings_str("Electrodynamics", "DiffuseAurora"));
 }
 
 // -----------------------------------------------------------------------
@@ -517,7 +737,7 @@ std::string Inputs::get_diffuse_auroral_model() {
 // -----------------------------------------------------------------------
 
 std::string Inputs::get_euv_model() {
-  return check_settings_str("Euv", "Model");
+  return mklower(check_settings_str("Euv", "Model"));
 }
 
 // -----------------------------------------------------------------------
@@ -533,7 +753,7 @@ precision_t Inputs::get_euv_heating_eff_neutrals() {
 // -----------------------------------------------------------------------
 
 bool Inputs::get_include_photoelectrons() {
-  return settings["Euv"]["IncludePhotoElectrons"];
+  return get_setting_bool("Euv", "IncludePhotoElectrons");
 }
 
 // -----------------------------------------------------------------------
@@ -565,32 +785,7 @@ precision_t Inputs::get_n_outputs() {
 // -----------------------------------------------------------------------
 
 int Inputs::get_original_seed() {
-  if (settings.find("Seed") == settings.end()) {
-    IsOk = false;
-    std::cout << "Error in getting seed!\n";
-    return 0;
-  }
-
-  return settings.at("Seed");
-}
-
-// -----------------------------------------------------------------------
-// Set random number seed
-// -----------------------------------------------------------------------
-
-void Inputs::set_seed(int seed) {
-  settings["Seed"] = seed;
-  updated_seed = seed;
-}
-
-// -----------------------------------------------------------------------
-// Return random number seed that has been updated
-// -----------------------------------------------------------------------
-
-int Inputs::get_updated_seed() {
-  std::default_random_engine get_random(updated_seed);
-  updated_seed = get_random();
-  return updated_seed;
+  return get_setting_int("Seed");
 }
 
 // -----------------------------------------------------------------------
@@ -633,68 +828,12 @@ int Inputs::get_nMembers() {
 // Return verbose variables
 // -----------------------------------------------------------------------
 
-bool Inputs::set_verbose(json in) {
-  bool DidWork = true;
-
-  int iVerbose = -1;
-
-  // Want to set verbose level ASAP:
-  if (in.contains("Debug")) {
-    if (in.at("Debug").contains("iVerbose")) {
-      iVerbose = in.at("Debug").at("iVerbose");
-
-      if (in.at("Debug").contains("iProc")) {
-        if (iProc != in.at("Debug").at("iProc"))
-          iVerbose = -1;
-      }
-    }
-  }
-
-  if (iVerbose > 0) {
-    std::cout << "Setting iVerbose : " << iVerbose << "\n";
-    report.set_verbose(iVerbose);
-  }
-
-  return DidWork;
-}
-
 int Inputs::get_verbose() {
   return check_settings_pt("Debug", "iVerbose");
 }
 
 int Inputs::get_verbose_proc() {
-  if (check_settings("Debug", "iProc"))
-    return settings.at("Debug").at("iProc");
-
-  return dummy_int;
-}
-
-// -----------------------------------------------------------------------
-// Return how often to output a given output type
-// -----------------------------------------------------------------------
-
-precision_t Inputs::get_dt_output(int iOutput) {
-  precision_t value = 0.0;
-  int nOutputs = settings.at("Outputs").at("type").size();
-
-  if (iOutput < nOutputs)
-    value = settings.at("Outputs").at("dt").at(iOutput);
-
-  return value;
-}
-
-// -----------------------------------------------------------------------
-// Return the output type
-// -----------------------------------------------------------------------
-
-std::string Inputs::get_type_output(int iOutput) {
-  std::string value = "unknown";
-  int nOutputs = settings.at("Outputs").at("type").size();
-
-  if (iOutput < nOutputs)
-    value = settings.at("Outputs").at("type").at(iOutput);
-
-  return value;
+  return get_setting_int("Debug", "iProc");
 }
 
 // -----------------------------------------------------------------------
@@ -738,32 +877,6 @@ std::string Inputs::get_indices_lookup_file() {
 }
 
 // -----------------------------------------------------------------------
-// Return total number of OMNIWeb files to read
-// -----------------------------------------------------------------------
-
-int Inputs::get_number_of_omniweb_files() {
-  if (settings.find("OmniwebFiles") != settings.end())
-    return settings.at("OmniwebFiles").size();
-
-  IsOk = false;
-  return dummy_int;
-}
-
-// -----------------------------------------------------------------------
-// Return OMNIWeb file names as a vector
-// -----------------------------------------------------------------------
-
-std::vector<std::string> Inputs::get_omniweb_files() {
-  std::vector<std::string> omniweb_files;
-  int nFiles = get_number_of_omniweb_files();
-
-  for (int i = 0; i < nFiles; i++)
-    omniweb_files.push_back(settings.at("OmniwebFiles").at(i));
-
-  return omniweb_files;
-}
-
-// -----------------------------------------------------------------------
 // Return F107 file to read
 // -----------------------------------------------------------------------
 
@@ -776,7 +889,7 @@ std::string Inputs::get_f107_file() {
 // -----------------------------------------------------------------------
 
 std::string Inputs::get_planet() {
-  return settings["Planet"]["name"];
+  return get_setting_str("Planet", "name");
 }
 
 // -----------------------------------------------------------------------
@@ -802,13 +915,7 @@ std::string Inputs::get_planet_species_file() {
 // -----------------------------------------------------------------------
 
 bool Inputs::get_do_calc_bulk_ion_temp() {
-  bool value = false;
-
-  if (check_settings("DoCalcBulkIonTemp"))
-    return settings.at("DoCalcBulkIonTemp");
-
-  IsOk = false;
-  return false;
+  return get_setting_bool("DoCalcBulkIonTemp");
 }
 
 // -----------------------------------------------------------------------
@@ -816,7 +923,7 @@ bool Inputs::get_do_calc_bulk_ion_temp() {
 // -----------------------------------------------------------------------
 
 precision_t Inputs::get_eddy_coef() {
-  return settings["Eddy"]["Coefficient"];
+  return get_setting_float("Eddy", "Coefficient");
 }
 
 // -----------------------------------------------------------------------
@@ -824,7 +931,7 @@ precision_t Inputs::get_eddy_coef() {
 // -----------------------------------------------------------------------
 
 precision_t Inputs::get_eddy_bottom() {
-  return settings["Eddy"]["BottomPressure"];
+  return get_setting_float("Eddy", "BottomPressure");
 }
 
 // -----------------------------------------------------------------------
@@ -832,7 +939,7 @@ precision_t Inputs::get_eddy_bottom() {
 // -----------------------------------------------------------------------
 
 precision_t Inputs::get_eddy_top() {
-  return settings["Eddy"]["TopPressure"];
+  return get_setting_float("Eddy", "TopPressure");
 }
 
 // -----------------------------------------------------------------------
@@ -840,16 +947,15 @@ precision_t Inputs::get_eddy_top() {
 // -----------------------------------------------------------------------
 
 bool Inputs::get_use_eddy_momentum() {
-  return settings["Eddy"]["UseInMomentum"];
+  return get_setting_bool("Eddy", "UseInMomentum");
 }
 
-// -----------------------------------------------------------------------
 // -----------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------
 
 bool Inputs::get_use_eddy_energy() {
-  return settings["Eddy"]["UseInEnergy"];
+  return get_setting_bool("Eddy", "UseInEnergy");
 }
 
 // -----------------------------------------------------------------------
@@ -857,12 +963,7 @@ bool Inputs::get_use_eddy_energy() {
 // -----------------------------------------------------------------------
 
 json Inputs::get_perturb_values() {
-  json values;
-
-  if (check_settings("Perturb"))
-    values = settings.at("Perturb");
-
-  return values;
+  return get_setting_json("Perturb");
 }
 
 // -----------------------------------------------------------------------
@@ -870,7 +971,7 @@ json Inputs::get_perturb_values() {
 // -----------------------------------------------------------------------
 
 bool Inputs::get_check_for_nans() {
-  return settings.at("Debug").at("check_for_nans");;
+  return get_setting_bool("Debug", "check_for_nans");
 }
 
 // -----------------------------------------------------------------------
@@ -878,7 +979,7 @@ bool Inputs::get_check_for_nans() {
 // -----------------------------------------------------------------------
 
 bool Inputs::get_nan_test() {
-  return settings.at("Debug").at("nan_test").at("insert");
+  return get_setting_bool("Debug", "nan_test", "insert");
 }
 
 // -----------------------------------------------------------------------
@@ -886,7 +987,7 @@ bool Inputs::get_nan_test() {
 // -----------------------------------------------------------------------
 
 std::string Inputs::get_nan_test_variable() {
-  return settings.at("Debug").at("nan_test").at("variable");
+  return get_setting_str("Debug", "nan_test", "variable");
 }
 
 // -----------------------------------------------------------------------
@@ -894,7 +995,7 @@ std::string Inputs::get_nan_test_variable() {
 // -----------------------------------------------------------------------
 
 bool Inputs::get_do_lat_dependent_radius() {
-  return settings["Oblate"]["isOblate"];
+  return get_setting_bool("Oblate", "isOblate");
 }
 
 // -----------------------------------------------------------------------
@@ -902,7 +1003,7 @@ bool Inputs::get_do_lat_dependent_radius() {
 // -----------------------------------------------------------------------
 
 bool Inputs::get_do_J2() {
-  return settings["Oblate"]["isJ2"];
+  return get_setting_bool("Oblate", "isJ2");
 }
 
 // -----------------------------------------------------------------------
@@ -910,12 +1011,7 @@ bool Inputs::get_do_J2() {
 // -----------------------------------------------------------------------
 
 json Inputs::get_initial_condition_types() {
-  json values;
-
-  if (check_settings("InitialConditions"))
-    values = settings.at("InitialConditions");
-
-  return values;
+  return get_setting_json("InitialConditions");
 }
 
 // -----------------------------------------------------------------------
@@ -923,34 +1019,11 @@ json Inputs::get_initial_condition_types() {
 // -----------------------------------------------------------------------
 
 json Inputs::get_boundary_condition_types() {
-  json values;
-
-  if (check_settings("BoundaryConditions"))
-    values = settings.at("BoundaryConditions");
-
-  return values;
+  return get_setting_json("BoundaryConditions");
 }
 
 std::string Inputs::get_advection_neutrals_vertical() {
-
-  std::string value = "none";
-
-  if (settings.contains("Advection"))
-    if (settings["Advection"].contains("Neutrals"))
-      if (settings["Advection"]["Neutrals"].contains("Vertical"))
-        value = settings["Advection"]["Neutrals"]["Vertical"];
-      else {
-        std::cout << "Error trying to get inputs:\n";
-        std::cout << "  settings['Advection']['Neutrals']['Vertical']\n";
-      } else {
-      std::cout << "Error trying to get inputs:\n";
-      std::cout << "  settings['Advection']['Neutrals']\n";
-    } else {
-    std::cout << "Error trying to get inputs:\n";
-    std::cout << "  settings['Advection']\n";
-  }
-
-  return value;
+  return get_setting_str("Advection", "Neutrals", "Vertical");
 }
 
 // --------------------------------------------------------------------------
@@ -958,5 +1031,5 @@ std::string Inputs::get_advection_neutrals_vertical() {
 // --------------------------------------------------------------------------
 
 bool Inputs::is_ok() {
-  return IsOk;
+  return isOk;
 }

--- a/src/inputs.cpp
+++ b/src/inputs.cpp
@@ -74,11 +74,13 @@ Inputs::Inputs(Times &time) {
 
 bool Inputs::write_restart() {
   bool didWork = true;
+
   if (iProc == 0) {
     std::string filename = get_setting_str("Restart", "OutDir");
     filename = filename + "/settings.json";
     didWork = write_json(filename, settings);
   }
+
   didWork = sync_across_all_procs(didWork);
   return didWork;
 }
@@ -86,7 +88,7 @@ bool Inputs::write_restart() {
 
 // -----------------------------------------------------------------------
 // General check functions to see if keys exist:
-// check settings and throw invalid_argument error 
+// check settings and throw invalid_argument error
 // if the setting doesn't exist
 // -----------------------------------------------------------------------
 
@@ -104,6 +106,7 @@ bool Inputs::check_settings(std::string key1,
     std::cout << "checking setting : "
               << key1 << " and "
               << key2 << "\n";
+
   //try to find the keys first
   if (settings.find(key1) != settings.end()) {
     if (settings.at(key1).find(key2) != settings.at(key1).end())
@@ -116,6 +119,7 @@ bool Inputs::check_settings(std::string key1,
     report.error("Error in setting : " + key1 + " : " + key2);
     std::cout << "Missing setting called! [" << key1 << ", " << key2 << "]\n";
   }
+
   return isOk;
 }
 
@@ -125,6 +129,7 @@ bool Inputs::check_settings(std::string key1,
 bool Inputs::check_settings(std::string key1) {
   if (report.test_verbose(1))
     std::cout << "checking setting : " << key1 << "\n";
+
   // try to find the keys first
   if (settings.find(key1) != settings.end())
     isOk = true;
@@ -137,6 +142,7 @@ bool Inputs::check_settings(std::string key1) {
     report.error("Error in setting : " + key1);
     std::cout << "Missing setting called! [" << key1 << "]\n";
   }
+
   return isOk;
 }
 
@@ -149,13 +155,16 @@ bool Inputs::check_settings(std::string key1) {
 
 std::vector<int> Inputs::get_setting_intarr(std::string key1) {
   std::vector<int> value;
+
   if (check_settings(key1)) {
     int nPts = settings.at(key1).size();
     isOk = true;
+
     for (int i = 0; i < nPts; i++)
       value.push_back(settings.at(key1).at(i));
   } else
     isOk = false;
+
   return value;
 }
 
@@ -166,13 +175,17 @@ std::vector<int> Inputs::get_setting_timearr(std::string key1) {
   int nPtsTime = 7;
   std::vector<int> outarr(nPtsTime, 0);
   std::vector<int> timearr = get_setting_intarr(key1);
+
   if (isOk) {
     int nPts = timearr.size();
+
     if (nPts > nPtsTime)
       nPts = nPtsTime;
+
     for (int i = 0; i < nPts; i++)
       outarr[i] = timearr[i];
   }
+
   return outarr;
 }
 
@@ -181,8 +194,10 @@ std::vector<int> Inputs::get_setting_timearr(std::string key1) {
 
 std::string Inputs::get_setting_str(std::string key1) {
   std::string value = "unknown";
+
   if (check_settings(key1))
     value = settings.at(key1);
+
   return value;
 }
 
@@ -192,8 +207,10 @@ std::string Inputs::get_setting_str(std::string key1) {
 std::string Inputs::get_setting_str(std::string key1,
                                     std::string key2) {
   std::string value = "unknown";
+
   if (check_settings(key1, key2))
     value = settings.at(key1).at(key2);
+
   return value;
 }
 
@@ -205,15 +222,18 @@ std::string Inputs::get_setting_str(std::string key1,
                                     std::string key3) {
   std::string value = "unknown";
   isOk = false;
+
   if (settings.find(key1) != settings.end())
     if (settings.at(key1).find(key2) != settings.at(key1).end())
-      if (settings.at(key1).at(key2).find(key3) != 
+      if (settings.at(key1).at(key2).find(key3) !=
           settings.at(key1).at(key2).end()) {
         value = settings.at(key1).at(key2).at(key3);
         isOk = true;
       }
+
   if (!isOk)
     report.error("Error in setting : " + key1 + " : " + key2 + " : " + key3);
+
   return value;
 }
 
@@ -222,8 +242,10 @@ std::string Inputs::get_setting_str(std::string key1,
 
 int64_t Inputs::get_setting_int(std::string key1) {
   int64_t value = LONG_MIN;
+
   if (check_settings(key1))
     value = settings.at(key1);
+
   return value;
 }
 
@@ -233,8 +255,10 @@ int64_t Inputs::get_setting_int(std::string key1) {
 int64_t Inputs::get_setting_int(std::string key1,
                                 std::string key2) {
   int64_t value = LONG_MIN;
+
   if (check_settings(key1, key2))
     value = settings.at(key1).at(key2);
+
   return value;
 }
 
@@ -243,8 +267,10 @@ int64_t Inputs::get_setting_int(std::string key1,
 
 bool Inputs::get_setting_bool(std::string key1) {
   bool value = false;
+
   if (check_settings(key1))
     value = settings.at(key1);
+
   return value;
 }
 
@@ -254,8 +280,10 @@ bool Inputs::get_setting_bool(std::string key1) {
 bool Inputs::get_setting_bool(std::string key1,
                               std::string key2) {
   bool value = false;
+
   if (check_settings(key1, key2))
     value = settings.at(key1).at(key2);
+
   return value;
 }
 
@@ -267,15 +295,18 @@ bool Inputs::get_setting_bool(std::string key1,
                               std::string key3) {
   bool value = false;
   isOk = false;
+
   if (settings.find(key1) != settings.end())
     if (settings.at(key1).find(key2) != settings.at(key1).end())
-      if (settings.at(key1).at(key2).find(key3) != 
+      if (settings.at(key1).at(key2).find(key3) !=
           settings.at(key1).at(key2).end()) {
         value = settings.at(key1).at(key2).at(key3);
         isOk = true;
       }
+
   if (!isOk)
     report.error("Error in setting : " + key1 + " : " + key2 + " : " + key3);
+
   return value;
 }
 
@@ -284,8 +315,10 @@ bool Inputs::get_setting_bool(std::string key1,
 
 precision_t Inputs::get_setting_float(std::string key1) {
   precision_t value = std::numeric_limits<precision_t>::lowest();
+
   if (check_settings(key1))
     value = settings.at(key1);
+
   return value;
 }
 
@@ -295,8 +328,10 @@ precision_t Inputs::get_setting_float(std::string key1) {
 precision_t Inputs::get_setting_float(std::string key1,
                                       std::string key2) {
   precision_t value = std::numeric_limits<precision_t>::lowest();
+
   if (check_settings(key1, key2))
-      value = settings.at(key1).at(key2);
+    value = settings.at(key1).at(key2);
+
   return value;
 }
 
@@ -305,12 +340,14 @@ precision_t Inputs::get_setting_float(std::string key1,
 
 json Inputs::get_setting_json(std::string key1) {
   json value;
+
   if (settings.find(key1) != settings.end())
     value = settings.at(key1);
   else {
     isOk = false;
     report.error("Error in setting : " + key1);
   }
+
   return value;
 }
 
@@ -320,17 +357,18 @@ json Inputs::get_setting_json(std::string key1) {
 json Inputs::get_setting_json(std::string key1,
                               std::string key2) {
   json value;
+
   if (settings.find(key1) != settings.end())
     if (settings.at(key1).find(key2) != settings.at(key1).end())
       value = settings.at(key1).at(key2);
     else {
       isOk = false;
       report.error("Error in setting : " + key1 + " : " + key2);
-    }
-  else {
+    } else {
     isOk = false;
     report.error("Error in setting : " + key1);
   }
+
   return value;
 }
 
@@ -341,6 +379,7 @@ std::string Inputs::check_settings_str(std::string key1,
                                        std::string key2) {
   if (check_settings(key1, key2))
     return settings.at(key1).at(key2);
+
   return dummy_string;
 }
 
@@ -352,6 +391,7 @@ std::string Inputs::check_settings_str(std::string key) {
     isOk = false;
     return dummy_string;
   }
+
   return settings[key];
 }
 
@@ -362,6 +402,7 @@ precision_t Inputs::check_settings_pt(std::string key1,
                                       std::string key2) {
   if (check_settings(key1, key2))
     return settings.at(key1).at(key2);
+
   isOk = false;
   return dummy_float;
 }
@@ -414,10 +455,12 @@ Inputs::grid_input_struct Inputs::get_grid_inputs() {
 bool Inputs::set_verbose(json in) {
   bool didWork = true;
   int iVerbose = -1;
+
   // Want to set verbose level ASAP:
   if (in.contains("Debug")) {
     if (in.at("Debug").contains("iVerbose")) {
       iVerbose = in.at("Debug").at("iVerbose");
+
       if (in.at("Debug").contains("iProc")) {
         if (iProc != in.at("Debug").at("iProc"))
           iVerbose = -1;
@@ -426,10 +469,12 @@ bool Inputs::set_verbose(json in) {
       didWork = false;
   } else
     didWork = false;
+
   if (iVerbose > 0) {
     std::cout << "Setting iVerbose : " << iVerbose << "\n";
     report.set_verbose(iVerbose);
   }
+
   return didWork;
 }
 
@@ -440,6 +485,7 @@ bool Inputs::set_verbose(json in) {
 int Inputs::get_number_of_omniweb_files() {
   if (settings.find("OmniwebFiles") != settings.end())
     return settings.at("OmniwebFiles").size();
+
   isOk = false;
   return dummy_int;
 }
@@ -451,8 +497,10 @@ int Inputs::get_number_of_omniweb_files() {
 std::vector<std::string> Inputs::get_omniweb_files() {
   std::vector<std::string> omniweb_files;
   int nFiles = get_number_of_omniweb_files();
+
   for (int i = 0; i < nFiles; i++)
     omniweb_files.push_back(settings.at("OmniwebFiles").at(i));
+
   return omniweb_files;
 }
 
@@ -509,8 +557,10 @@ int Inputs::get_updated_seed() {
 
 std::string Inputs::get_logfile() {
   std::string logfile = get_setting_str("Logfile", "name");
+
   if (nMembers > 1)
     logfile = add_cmember(logfile);
+
   return logfile;
 }
 
@@ -521,8 +571,10 @@ std::string Inputs::get_logfile() {
 std::vector<std::string> Inputs::get_species_vector() {
   std::vector<std::string> species;
   const json &json_species = get_setting_json("Logfile", "species");
+
   for (size_t iOutput = 0; iOutput < json_species.size(); iOutput++)
     species.push_back(json_species.at(iOutput));
+
   return species;
 }
 
@@ -533,8 +585,10 @@ std::vector<std::string> Inputs::get_species_vector() {
 std::vector<std::string> Inputs::get_satellite_files() {
   std::vector<std::string> files;
   const json &json_files = get_setting_json("Satellites", "files");
+
   for (size_t i = 0; i < json_files.size(); ++i)
     files.push_back(json_files.at(i));
+
   return files;
 }
 
@@ -545,8 +599,10 @@ std::vector<std::string> Inputs::get_satellite_files() {
 std::vector<std::string> Inputs::get_satellite_names() {
   std::vector<std::string> names;
   const json &json_names = get_setting_json("Satellites", "names");
+
   for (size_t i = 0; i < json_names.size(); ++i)
     names.push_back(json_names.at(i));
+
   return names;
 }
 
@@ -557,8 +613,10 @@ std::vector<std::string> Inputs::get_satellite_names() {
 std::vector<precision_t> Inputs::get_satellite_dts() {
   std::vector<precision_t> dts;
   const json &json_dts = get_setting_json("Satellites", "dts");
+
   for (size_t i = 0; i < json_dts.size(); ++i)
     dts.push_back(json_dts.at(i));
+
   return dts;
 }
 

--- a/src/ions.cpp
+++ b/src/ions.cpp
@@ -66,17 +66,17 @@ Ions::Ions(Grid grid, Planets planet) {
     species.push_back(tmp);
   }
 
-  velocity_name.push_back("Ion Velocity (Zonal)");
-  velocity_name.push_back("Ion Velocity (Meridional)");
-  velocity_name.push_back("Ion Velocity (Vertical)");
+  velocity_name.push_back("velocity_east");
+  velocity_name.push_back("velocity_north");
+  velocity_name.push_back("velocity_up");
 
-  par_velocity_name.push_back("Parallel Ion Velocity (Zonal)");
-  par_velocity_name.push_back("Parallel Ion Velocity (Meridional)");
-  par_velocity_name.push_back("Parallel Ion Velocity (Vertical)");
+  par_velocity_name.push_back("velocity_parallel_east");
+  par_velocity_name.push_back("velocity_parallel_north");
+  par_velocity_name.push_back("velocity_parallel_up");
 
-  perp_velocity_name.push_back("Perp. Ion Velocity (Zonal)");
-  perp_velocity_name.push_back("Perp. Ion Velocity (Meridional)");
-  perp_velocity_name.push_back("Perp. Ion Velocity (Vertical)");
+  perp_velocity_name.push_back("velocity_perp_east");
+  perp_velocity_name.push_back("velocity_perp_north");
+  perp_velocity_name.push_back("velocity_perp_up");
 
   // Create one extra species for electrons
   tmp = create_species(grid);

--- a/src/neutrals.cpp
+++ b/src/neutrals.cpp
@@ -88,9 +88,9 @@ Neutrals::Neutrals(Grid grid,
     species.push_back(tmp);
   }
 
-  velocity_name.push_back("Zonal Wind");
-  velocity_name.push_back("Meridional Wind");
-  velocity_name.push_back("Vertical Wind");
+  velocity_name.push_back("velocity_east");
+  velocity_name.push_back("velocity_north");
+  velocity_name.push_back("velocity_up");
 
   // State variables:
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -112,7 +112,7 @@ bool output(const Neutrals &neutrals,
           type_output == "states")
         for (int iSpecies = 0; iSpecies < neutrals.nSpecies; iSpecies++)
           AllOutputContainers[iOutput].
-          store_variable(neutrals.species[iSpecies].cName,
+          store_variable("density_" + neutrals.species[iSpecies].cName,
                          neutrals.density_unit,
                          neutrals.species[iSpecies].density_scgc);
 
@@ -120,7 +120,7 @@ bool output(const Neutrals &neutrals,
       if (type_output == "neutrals" ||
           type_output == "states")
         AllOutputContainers[iOutput].
-        store_variable(neutrals.temperature_name,
+        store_variable(neutrals.temperature_name + "_neutral",
                        neutrals.temperature_unit,
                        neutrals.temperature_scgc);
 
@@ -129,7 +129,7 @@ bool output(const Neutrals &neutrals,
           type_output == "states")
         for (int iDir = 0; iDir < 3; iDir++)
           AllOutputContainers[iOutput].
-          store_variable(neutrals.velocity_name[iDir],
+          store_variable(neutrals.velocity_name[iDir] + "_neutral",
                          neutrals.velocity_unit,
                          neutrals.velocity_vcgc[iDir]);
 
@@ -138,8 +138,8 @@ bool output(const Neutrals &neutrals,
         for (int iSpecies = 0; iSpecies < neutrals.nSpecies; iSpecies++)
           for (int iDir = 0; iDir < 3; iDir++)
             AllOutputContainers[iOutput].
-            store_variable(neutrals.species[iSpecies].cName + " " +
-                           neutrals.velocity_name[iDir],
+            store_variable(neutrals.velocity_name[iDir] + "_" +
+                           neutrals.species[iSpecies].cName,
                            neutrals.velocity_unit,
                            neutrals.species[iSpecies].velocity_vcgc[iDir]);
 
@@ -148,7 +148,7 @@ bool output(const Neutrals &neutrals,
           type_output == "states")
         for (int iSpecies = 0; iSpecies <= ions.nSpecies; iSpecies++)
           AllOutputContainers[iOutput].
-          store_variable(ions.species[iSpecies].cName,
+          store_variable("density_" + ions.species[iSpecies].cName,
                          ions.density_unit,
                          ions.species[iSpecies].density_scgc);
 
@@ -157,23 +157,22 @@ bool output(const Neutrals &neutrals,
           type_output == "states")
         for (int iSpecies = 0; iSpecies <= ions.nSpecies; iSpecies++)
           AllOutputContainers[iOutput].
-          store_variable(ions.species[iSpecies].cName + " " + ions.temperature_name,
+          store_variable(ions.temperature_name + "_" + 
+                         ions.species[iSpecies].cName,
                          ions.temperature_unit,
                          ions.species[iSpecies].temperature_scgc);
 
       // Bulk Ion Temperature:
       if (type_output == "ions" ||
           type_output == "states")
-        AllOutputContainers[iOutput].store_variable("Bulk Ion " +
-                                                    ions.temperature_name,
+        AllOutputContainers[iOutput].store_variable(ions.temperature_name + "_ion",
                                                     ions.temperature_unit,
                                                     ions.temperature_scgc);
 
       // Bulk Ion Drifts:
       if (type_output == "states")
         for (int iDir = 0; iDir < 3; iDir++)
-          AllOutputContainers[iOutput].store_variable("Bulk " +
-                                                      ions.velocity_name[iDir],
+          AllOutputContainers[iOutput].store_variable(ions.velocity_name[iDir] + "_ion",
                                                       ions.velocity_unit,
                                                       ions.velocity_vcgc[iDir]);
 
@@ -251,15 +250,15 @@ bool output(const Neutrals &neutrals,
       }
 
       if (type_output == "moment") {
-        AllOutputContainers[iOutput].store_variable("Cent Acc East",
+        AllOutputContainers[iOutput].store_variable("accel_cent_east",
                                                     "Logitudinal Centripetal Acceleration",
                                                     "m/s^2",
                                                     grid.cent_acc_vcgc[0]);
-        AllOutputContainers[iOutput].store_variable("Cent Acc North",
+        AllOutputContainers[iOutput].store_variable("accel_cent_north",
                                                     "Latitudinal Centripetal Acceleration",
                                                     "m/s^2",
                                                     grid.cent_acc_vcgc[1]);
-        AllOutputContainers[iOutput].store_variable("Cent Acc Vert",
+        AllOutputContainers[iOutput].store_variable("accel_cent_up",
                                                     "Radial Centripetal Acceleration",
                                                     "m/s^2",
                                                     grid.cent_acc_vcgc[2]);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -157,7 +157,7 @@ bool output(const Neutrals &neutrals,
           type_output == "states")
         for (int iSpecies = 0; iSpecies <= ions.nSpecies; iSpecies++)
           AllOutputContainers[iOutput].
-          store_variable(ions.temperature_name + "_" + 
+          store_variable(ions.temperature_name + "_" +
                          ions.species[iSpecies].cName,
                          ions.temperature_unit,
                          ions.species[iSpecies].temperature_scgc);

--- a/src/read_input_file.cpp
+++ b/src/read_input_file.cpp
@@ -21,23 +21,20 @@
 
 bool Inputs::read_inputs_json(Times &time) {
 
-  bool DidWork = true;
-
   json defaults;
   json user_inputs;
 
+  isOk = true;
+
   // Set the default values first:
   settings = read_json("UA/inputs/defaults.json");
-  DidWork = set_verbose(settings);
-
-  // Set the planet-specific file (user can change this in aether.in file!):
-  settings["PlanetSpeciesFile"] = settings["Planet"]["file"];
+  isOk = set_verbose(settings);
 
   try {
 
     // Then read in user perturbations on those defaults:
     user_inputs = read_json("aether.json");
-    DidWork = set_verbose(user_inputs);
+    isOk = set_verbose(user_inputs);
 
     // Read in a restart file also if user specified it.
     //   - Here we merge the restart inputs with the defaults inputs
@@ -46,7 +43,7 @@ bool Inputs::read_inputs_json(Times &time) {
     if (user_inputs.contains("Restart")) {
       if (user_inputs["Restart"].contains("do")) {
         if (user_inputs["Restart"]["do"]) {
-          std::string restart_file = settings["Restart"]["InDir"];
+          std::string restart_file = get_setting_str("Restart", "InDir");
           restart_file = restart_file + "/settings.json";
           json restart_inputs;
           restart_inputs = read_json(restart_file);
@@ -63,31 +60,39 @@ bool Inputs::read_inputs_json(Times &time) {
     settings.merge_patch(user_inputs);
 
     //change planet file to the one specified on aether.json:
-    settings["PlanetSpeciesFile"] = settings["PlanetFile"];
+    if (isOk)
+      settings["PlanetSpeciesFile"] = get_setting_str("PlanetFile");
 
-    std::string planet_filename = settings["PlanetSpeciesFile"];
+    std::string planet_filename = get_setting_str("PlanetSpeciesFile");
     report.print(1, "Using planet file : " + planet_filename);
 
     // Debug Stuff:
-    report.set_verbose(get_settings("Debug", "iVerbose"));
-    report.set_DefaultVerbose(get_settings("Debug", "iVerbose"));
-    report.set_doInheritVerbose(settings["Debug"]["doInheritVerbose"]);
-    report.set_timing_depth(get_settings("Debug", "iTimingDepth"));
-    report.set_timing_percent(settings["Debug"]["TimingPercent"]);
-    report.set_iProc(get_settings("Debug", "iProc"));
+    if (isOk)
+      report.set_verbose(get_setting_int("Debug", "iVerbose"));
+    if (isOk)
+      report.set_DefaultVerbose(get_setting_int("Debug", "iVerbose"));
+    if (isOk)
+      report.set_doInheritVerbose(get_setting_bool("Debug", "doInheritVerbose"));
+    if (isOk)
+      report.set_timing_depth(get_setting_int("Debug", "iTimingDepth"));
+    if (isOk)
+      report.set_timing_percent(get_setting_float("Debug", "TimingPercent"));
+    if (isOk)
+      report.set_iProc(get_setting_int("Debug", "iProc"));
 
     for (auto &item : settings["Debug"]["iFunctionVerbose"].items())
       report.set_FunctionVerbose(item.key(), item.value());
 
     // Capture time information:
-    std::vector<int> istart = get_settings_timearr("StartTime");
-    time.set_times(istart);
+    if (isOk)
+      time.set_times(get_setting_timearr("StartTime"));
+    if (isOk)
+      time.set_end_time(get_setting_timearr("EndTime"));
 
-    std::vector<int> iend = get_settings_timearr("EndTime");
-    time.set_end_time(iend);
   } catch (...) {
-    DidWork = false;
+    report.error("Error in reading inputs!");
+    isOk = false;
   }
 
-  return DidWork;
+  return isOk;
 }

--- a/src/read_input_file.cpp
+++ b/src/read_input_file.cpp
@@ -69,14 +69,19 @@ bool Inputs::read_inputs_json(Times &time) {
     // Debug Stuff:
     if (isOk)
       report.set_verbose(get_setting_int("Debug", "iVerbose"));
+
     if (isOk)
       report.set_DefaultVerbose(get_setting_int("Debug", "iVerbose"));
+
     if (isOk)
       report.set_doInheritVerbose(get_setting_bool("Debug", "doInheritVerbose"));
+
     if (isOk)
       report.set_timing_depth(get_setting_int("Debug", "iTimingDepth"));
+
     if (isOk)
       report.set_timing_percent(get_setting_float("Debug", "TimingPercent"));
+
     if (isOk)
       report.set_iProc(get_setting_int("Debug", "iProc"));
 
@@ -86,6 +91,7 @@ bool Inputs::read_inputs_json(Times &time) {
     // Capture time information:
     if (isOk)
       time.set_times(get_setting_timearr("StartTime"));
+
     if (isOk)
       time.set_end_time(get_setting_timearr("EndTime"));
 


### PR DESCRIPTION
# Description

Addresses #70 and #144 

The output variable names are changed to not have spaces or parentheses.

The input settings checking is simplified and made more consistent - now developers can simply use the get_settings_xx(key, key) functions.  These functions check if the keys exist and then set an error flag if they don't. Much more robust!

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change that adds functionality)

# How Has This Been Tested?

Run the default test case.

One issue with testing these things is that the default.json file has correct settings, so if the user sets a setting incorrectly in the aether.json file, it will simply ADD to the settings json and not overwrite the default setting, since this is how json merge works.

## Test configuration

* Operating system: WSL Ubuntu
* Compiler, version number: gcc 11

# Checklist:

- [N/A] Make sure you are merging into the ``develop`` (not ``master``) branch
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [N/A] Add a note to ``CHANGELOG.md``, summarizing the changes
