### PR TITLE
Exchange messages interpolation

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -87,7 +87,7 @@ cmake -DCMAKE_CXX_COMPILER=<gcc or mpi executable with full path>
 Finally, run the make command in the build directory:
 
 ```bash
-make -jN
+make [-jN]
 ```
 
 The `-j` flag tells the computer the number of processers to use when running

--- a/doc/running_aether.md
+++ b/doc/running_aether.md
@@ -1,0 +1,223 @@
+# Running Aether
+
+See the installation.md document for how to install Aether.
+
+## The first run
+
+Once you have compiled you can run Aether. To remember which runs you're doing,
+we recommend creating a specific directory for each run.  This can be done by
+copying the default run directory to have a special name, like this:
+```bash
+cd ..
+cp -R share/run ./run.first_run
+```
+
+This creates the directory where you will do your run.  In that directory is a link to the aether executable and an input file called aether.json.
+
+You can then run the executable from the directory you created.
+```bash
+cd run.first_run
+./aether
+```
+You should see something like:
+```bash
+run.first_run% ./aether
+> Need to NOT adjust F10.7, but that isn't included yet!!!
+> Writing file : 3DALL_20110320_000000
+> Writing file : 3DBFI_20110320_000000
+> Wall Time : 4s (left : 1111h); Current Time : 2011 3 20 0 0 0 0 
+> Wall Time : 4s (left : 23m); Current Time : 2011 3 20 0 0 10 0 
+> Wall Time : 5s (left : 14m); Current Time : 2011 3 20 0 0 20 0 
+> Wall Time : 5s (left : 9m); Current Time : 2011 3 20 0 0 30 0 
+> Wall Time : 5s (left : 7m); Current Time : 2011 3 20 0 0 40 0 
+> Wall Time : 6s (left : 7m); Current Time : 2011 3 20 0 0 50 0 
+> Wall Time : 6s (left : 5m); Current Time : 2011 3 20 0 1 0 0 
+> Wall Time : 6s (left : 5m); Current Time : 2011 3 20 0 1 10 0 
+> Wall Time : 7s (left : 5m); Current Time : 2011 3 20 0 1 20 0 
+> Wall Time : 7s (left : 4m); Current Time : 2011 3 20 0 1 30 0 
+etc.
+```
+
+The successful end of this will show a timing summary, similar to:
+```bash
+>main>advance>Chemistry::calc_chemistry
+    nTimes called : 720
+    timing_total (s) : 1.52599
+>main>advance>Ions::calc_ion_temperature
+    nTimes called : 720
+    timing_total (s) : 19.0279
+>main>advance>Neutrals::exchange
+    nTimes called : 720
+    timing_total (s) : 2.94398
+```
+
+## Output Files
+
+Aether outputs to a subdirectory called UA/output. At this time, all processors within the Aether run output their own files and they can be combined using the post processor.
+
+### Blocks
+
+Aether is a block-based code, so the domain is split up into different blocks that hold a given volume (for spherical grids, this is some range of latitude, longitude and altitude; for other grids it could differ). If you asked for (for example) 4 processors, then the Earth would be broken up into 4 different blocks and each output would consist of 4 different blocks.
+
+### Ensembles
+
+Aether can run the same simulation multiple times simultaneously with different drivers and internal parameters.  The collection of these simulations is called an ensemble, with each individual simulation called a member.  All of the ensemble members output to the UA/output directory.  See the ensembles.md document to learn more about ensembles.
+
+### Post processing
+
+Because there can be multiple blocks and multiple ensemble members, there is a post processor that can pull all of the files together. By default, the post processor combines all of the block files for one ensemble member for one time into one file.  This means that if there are 25 hourly outputs requested, there will be 25 total files for each ensemble member.
+
+If there is more than one simulation, then the post processor will create a mean file for each time.  If there are more than two ensemble members, a standard deviation file is also created.  The mean and standard deviations are calculated across ensemble members.
+
+To run the post processor, do the following:
+
+```bash
+cd UA/output
+../../../srcPython/post_process.py
+```
+
+By default, this will also leave the raw files and will produce plots just to make sure that everything is working ok.  If you don't need the raw files (there is not a good reason to keep these, unless you are debugging the post processor), you can run the post-processor with the "-rm" argument.  If you don't want any plots, you can run with the "-alt=-1" argument.  An example of this is (this is how it is often run):
+
+```bash
+../../../srcPython/post_process.py -rm -alt=-1
+```
+
+If you are going to be using Aether a lot, you may want to copy the post-processor into your bin directory.
+
+## Input Files
+
+Aether reads in a bunch of files, most of which are specified by the settings file.  In order to minimize the number of places where new settings need to be specified, Aether uses a defaults file that sets the generic defaults of the model.  This file is in UA/inputs/defaults.json.  
+
+## defaults.json file
+
+This is a json file that sets all of the defaults within Aether.  This file should never be modified!
+
+### For Developers
+
+Within Aether, the inputs.cpp file has a large handful of of get_ routines to get the values of the settings that the user has set. 
+
+## aether.json file
+
+The file aether.json is read in AFTER the defaults file and these settings overwrite the defaults.  So, if you want to modify the default settings, simply copy a setting out of defaults.json and paste it into aether.json.  Then, you can modify the setting in aether.json.
+
+Because the files are json files, you don't actually have to set all of the subsettings within a specific setting.  For example, within the defaults.json file, the EUV setting is:
+
+```bash
+    "Euv" : {
+		"doUse" : true,
+		"Model" : "euvac",
+		"File" : "UA/inputs/euv.csv",
+		"IncludePhotoElectrons" : true,
+		"HeatingEfficiency" : 0.05,
+		"dt" : 60.0},
+```
+
+If you simply want to turn off the EUV, you can insert this into the aether.json file:
+
+```bash
+    "Euv" : {
+		"doUse" : false},
+```
+
+or, if you wanted to use the 59 wavelength bins instead of the 37 EUVAC bins, you could do:
+
+```bash
+    "Euv" : {
+		"File" : "UA/inputs/euv_59.csv"},
+```
+
+## planet.in file
+
+Within the input file, the planet file can be set:
+
+```bash
+    "Planet" : {
+        "name" : "earth",
+        "file": "UA/inputs/earth.in"},
+```
+
+This file defines the neutrals and ions to be modeled. For example:
+
+```bash
+#NEUTRALS
+name, mass, vibration, thermal_cond, thermal_exp, advect, BC
+O, 16, 5, 5.6e-4, 0.69, 1, 5.0e17
+N, 14, 5, 5.6e-4, 0.69, 1, 2.5e11
+O2, 32, 7, 3.6e-4, 0.69, 1, 4.0e18
+N2, 28, 7, 3.6e-4, 0.69, 1, 1.7e19
+NO, 30, 7, 3.6e-4, 0.69, 1, 5.4e14
+He, 4, 5, 5.6e-4, 0.69, 1, 1.5e14
+N_2D, 14, 5, 5.6e-4, 0.69, 0, 2.5e9
+N_2P, 14, 5, 5.6e-4, 0.69, 0, 2.5e7
+H, 1, 5, 5.6e-4, 0.69, 0, 3.0e13
+O_1D, 16, 5, 5.6e-4, 0.69, 0, 1.0e10
+CO2, 46, 7, 3.6e-4, 0.69, 0, 4.5e15
+```
+
+This is a comma seperated list that includes:
+- name - this is the common name of the species
+- mass - the atomic mass of the species
+- vibration - the degrees of freedom for the species
+- thermal_cond - the thermal conductivity coeficient of the species
+- thermal_exp - the exponent that is put on the temperature (Lambda = A * T^B)
+- advect - whether the species is advected or not 
+- BC - the lower boundary condition on the species density
+
+```bash
+#IONS
+name, mass, charge, advect
+O+, 16, 1, 1
+O2+, 32, 1, 0
+N2+, 28, 1, 0
+NO+, 30, 1, 0
+N+, 14, 1, 0
+He+, 4, 1, 1
+O+_2D, 16, 1, 0
+O+_2P, 16, 1, 0
+```
+
+This is a comma separated list that includes:
+- name - this is the common name of the species
+- mass - the atomic mass of the species
+- charge - the charge of the species
+- advect - whether the species is advected or not 
+
+```bash
+#TEMPERATURE
+alt, temp
+100.0, 200.0
+200.0, 800.0
+300.0, 800.0
+```
+
+Within the input file (i.e., aether.json), the following can be set:
+
+```bash
+    "InitialConditions" : {
+	    "type" : "Planet"},    
+
+    "BoundaryConditions" : {
+	    "type" : "Planet"},
+```
+
+If these are set to "Planet", then the temperature profile is set as the initial condition.  If the boundary condition is set to "Planet", then the lowest altitude is used as a boundary condition on the temperature.
+
+## orbits.csv file
+
+This file contains all of the orbital, mass, rotation, and magnetic field characteristics of the planets.  All of the planets within the solar system are included.  Other planets (like exo-planets or artificial planets) can be included by adding lines.  
+
+## chemistry file
+
+The chemistry file defines all of the chemical reactions within the system.
+
+For example:
+```bash
+He+ + e- -> He, with  R = 4.8e-18 * (250 / Te) ^ 0.7
+```
+With an exothermal energy of xxx. Also, the uncertainty of the reaction can be set too (set to 10%, or 0.1).
+
+```bash
+R11,He+,e-,,,He,,,4.80E-18,(250/Te)^0.7,,1,0,,0.1,,,,gitm,250,Te,0.7,,,,1,
+```
+
+

--- a/doc/student.md
+++ b/doc/student.md
@@ -26,7 +26,9 @@ emacs can be installed using a package manager such as apt or port
 
 21st Century Editors:
 
-1. There are always popular Integrated Development Environments (IDEs) that can
+1. Most people are using Visual Studio Code to work on Aether.
+
+2. There are always popular Integrated Development Environments (IDEs) that can
    be used to edit, develop, and test code.  If you use one and develop on
    Aether, please feel free to update this section.
 
@@ -44,7 +46,7 @@ this:
 3. Click "Create fork"
 
 4. GitHub will take you to this repository automatically.  It is now your
-   "version" of Aether, and all development will be done here.  Will will use
+   "version" of Aether, and all development will be done here.  We will use
    the username "YourRepo" instead of your actual repository in the
    examples below.
 

--- a/include/grid.h
+++ b/include/grid.h
@@ -30,6 +30,7 @@ public:
   arma_cube A11_inv_scgc, A12_inv_scgc, A21_inv_scgc, A22_inv_scgc;
   arma_cube g11_upper_scgc, g12_upper_scgc, g21_upper_scgc, g22_upper_scgc;
   arma_cube sqrt_g_scgc;
+  arma_cube refx_angle, refy_angle;
 
   // Edge/Corner coordinates
   arma_cube geoLon_Left;
@@ -52,6 +53,8 @@ public:
   arma_cube A11_inv_Left, A12_inv_Left, A21_inv_Left, A22_inv_Left;
   arma_cube g11_upper_Left, g12_upper_Left, g21_upper_Left, g22_upper_Left;
   arma_cube sqrt_g_Left;
+  arma_mat refx_angle_Left, refy_angle_Left;
+  arma_mat refx_angle_Down, refy_angle_Down;
 
   arma_cube A11_Down, A12_Down, A21_Down, A22_Down;
   arma_cube A11_inv_Down, A12_inv_Down, A21_inv_Down, A22_inv_Down;
@@ -215,9 +218,15 @@ public:
     MPI_Request requests;
     precision_t* buffer;
     precision_t* rbuffer;
+
+    // For cubesphere. these are needed for interpolation
+    // when the cells go onto a different face:
+    arma_mat index;
+    arma_mat ratio;
   };
 
   std::vector<messages_struct> interchanges;
+  std::vector<messages_struct> interchangesOneVar;
 
   messages_struct make_new_interconnection(int64_t iDir,
 					   int64_t nVars,
@@ -229,7 +238,9 @@ public:
 					   bool XbecomesY);
 
   bool send_one_face(int64_t iFace);
+  bool send_one_var_one_face(int64_t iFace);
   bool receive_one_face(int64_t iFace);
+  bool receive_one_var_one_face(int64_t iFace);
 
   /**
    * \brief Set the interpolation coefficients

--- a/include/grid.h
+++ b/include/grid.h
@@ -227,6 +227,7 @@ public:
 
   std::vector<messages_struct> interchanges;
   std::vector<messages_struct> interchangesOneVar;
+  bool gcInterpolationSet = false;
 
   messages_struct make_new_interconnection(int64_t iDir,
 					   int64_t nVars,

--- a/include/parallel.h
+++ b/include/parallel.h
@@ -79,4 +79,45 @@ bool unpack_border(arma_cube &value,
 		   bool DoReverseY,
 		   bool XbecomesY);
 
+/**********************************************************************
+  \brief initialize the grid variables to set up ghostcell message passing 
+  \param grid the grid to set up message passing on
+  \param nVarsToPass how many variables to pass
+**/
+
+bool exchange_sides_init(Grid &grid, int64_t nVarsToPass);
+
+/**********************************************************************
+  \brief exchange one variable's ghost cells to adjacent blocks
+  \param grid the grid that describes the system
+  \param vat_to_pass is variable to pass
+  \param doReverseSignAcrossPole true for east/north vector components
+**/
+
+bool exchange_one_var(Grid &grid,
+		      arma_cube &var_to_pass,
+		      bool doReverseSignAcrossPole);
+
+/**********************************************************************
+  \brief test the exchange messages one var function
+  \param grid the grid that describes the system
+**/
+
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+
+arma_cube interpolate_ghostcells(arma_cube varIn, Grid &grid);
+
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+
+bool test_ghostcell_interpolation(Grid &grid);
+
+// -----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
+
+bool find_ghostcell_interpolation_coefs(Grid &grid);
+
+
+
 #endif  // INCLUDE_PARALLEL_H_

--- a/include/times.h
+++ b/include/times.h
@@ -95,6 +95,13 @@ public:
   std::string get_YMD_HMS();
 
   /**************************************************************
+     \brief Returns the current time as a string (year, month...)
+
+     Returns the current time as a string of format YYYYMMDD_HHMM00
+   **/
+  std::string get_YMD_HM0();
+
+  /**************************************************************
      \brief Returns the intermediate time in seconds since ref date
    **/
   double get_intermediate();
@@ -220,6 +227,9 @@ private:
 
   /// represented as YYYYMMDD_HHMMSS
   std::string sYMD_HMS;
+
+  /// represented as YYYYMMDD_HHMM00
+  std::string sYMD_HM0;
 
   // -------------------------------------------------------------
   // Keeping track of walltime for the run:

--- a/include/tools.h
+++ b/include/tools.h
@@ -15,6 +15,36 @@ struct mat_2x2{
     arma_mat A22;
 };
 
+// -----------------------------------------------------------------------------
+// find interpolation coefficients for a 1D interpolator
+//   inX is the grid you are interpolating FROM
+//   outX is the position you want to interpolate TO
+//   outIndex and outRatio are the interpolation coefficents
+// -----------------------------------------------------------------------------
+
+bool find_interpolation_coefficients(arma_vec inX,
+				     arma_vec outX,
+				     arma_vec &outIndex,
+				     arma_vec &outRatio);
+
+// -----------------------------------------------------------------------------
+// This takes the index and ratio determined in the above function and
+// uses them to interpolate.
+// -----------------------------------------------------------------------------
+
+arma_vec interpolate1d(arma_vec inY,
+		       arma_vec &index,
+		       arma_vec &ratio);
+
+// -----------------------------------------------------------------------------
+// Set all of the ghost cells to a constant value that is fed in.
+//   This is primarily for testing of message passing.
+// -----------------------------------------------------------------------------
+
+void set_gcs_to_value(arma_cube &var_scgc,
+		      precision_t value,
+		      int64_t nGCs);
+
 // ----------------------------------------------------------------------------
 // Fix corners in an arma cube
 //   - basically fill in the corners with values near them

--- a/share/run/UA/inputs/defaults.json
+++ b/share/run/UA/inputs/defaults.json
@@ -21,16 +21,16 @@
 	"type" : "Planet"},
 
     "Advection" : {
-	"Neutrals" : {
-	    "Vertical" : "rusanov",
-	    "Horizontal" : "default"},
-	"Ions" : {
-	    "Along" : "rusanov",
-	    "Across" : "default"} },
+		"Neutrals" : {
+	    	"Vertical" : "rusanov",
+	    	"Horizontal" : "default"},
+		"Ions" : {
+	    	"Along" : "rusanov",
+	    	"Across" : "default"} },
     
     "Student" : {
-	"name" : "",
-	"is" : false },
+		"name" : "",
+		"is" : false },
 
     "Planet" : {
         "name" : "earth",
@@ -39,18 +39,18 @@
     "BField" : "dipole",
 
     "Electrodynamics" : {
-	"Potential" : "weimer",
-	"DiffuseAurora" : "fta",
-	"Dir" : "UA/inputs/ext/ie/",
-	"File" : ""},
+		"Potential" : "weimer",
+		"DiffuseAurora" : "fta",
+		"Dir" : "UA/inputs/ext/ie/",
+		"File" : ""},
 
     "Euv" : {
-	"doUse" : true,
-	"Model" : "euvac",
-	"File" : "UA/inputs/euv.csv",
-	"IncludePhotoElectrons" : true,
-	"HeatingEfficiency" : 0.05,
-	"dt" : 60.0},
+		"doUse" : true,
+		"Model" : "euvac",
+		"File" : "UA/inputs/euv.csv",
+		"IncludePhotoElectrons" : true,
+		"HeatingEfficiency" : 0.05,
+		"dt" : 60.0},
 
     "DoCalcBulkIonTemp" : false,
     

--- a/share/run/UA/inputs/defaults.json
+++ b/share/run/UA/inputs/defaults.json
@@ -106,7 +106,6 @@
     "IndicesLookupFile" : "UA/inputs/indices_lookup.json",
 
     "OnmiwebFile" : [""],
-    "ElectrodynamicsFile" : [""],
     
     "Logfile" : {
 	"name" : "UA/output/log.txt",

--- a/share/run/aether.json
+++ b/share/run/aether.json
@@ -1,39 +1,38 @@
 
 {
     "Ensembles" : {
-	"nMembers" : 1},
+        "nMembers" : 1},
 
     "Debug" : {
-	"iVerbose" : 0,
+        "iVerbose" : 0,
         "iFunctionVerbose" : {
             "Grid::create_altitudes": 0},	
-	"dt" : 10.0,
-	"check_for_nans" : false
+        "dt" : 10.0,
+        "check_for_nans" : false
     },
 
     "EndTime" : [2011, 3, 20, 0, 10, 0],
 
     "GeoBlockSize" : {
-	"nLons" : 18,
-	"nLats" : 18,
-	"nAlts" : 50},
+        "nLons" : 18,
+        "nLats" : 18,
+        "nAlts" : 50},
 
     "GeoGrid" : {
-	"dAlt"   : 0.25,
-	"IsUniformAlt" : false},    
+        "dAlt"   : 0.25,
+        "IsUniformAlt" : false},    
 
     "OmniwebFiles" : ["UA/inputs/omni_20110319.txt"],
 
     "Electrodynamics" : {
-	"Potential" : "Weimer05",
-	"DiffuseAurora" : "fta"},
-
-    "ElectrodynamicsFile" : "UA/inputs/b20110320n_omni.bin",
+        "Potential" : "Weimer05",
+        "DiffuseAurora" : "fta",
+        "File": "UA/inputs/b20110320n_omni.bin"},
     
     "Outputs" : {
-	"type" : ["states"],
-	"dt" : [900] },
-    
+        "type" : ["states", "grid"],
+        "dt" : [900, -1] },
+
     "DoCalcBulkIonTemp" : false,
     
     "PlanetFile" : "UA/inputs/earth.in"

--- a/src/advance.cpp
+++ b/src/advance.cpp
@@ -116,7 +116,7 @@ bool advance(Planets &planet,
     ions.calc_electron_temperature(neutrals, gGrid);
 
     if (input.get_is_cubesphere())
-      neutrals.exchange(gGrid);
+      neutrals.exchange_old(gGrid);
     else
       neutrals.exchange_old(gGrid);
 

--- a/src/exchange_messages.cpp
+++ b/src/exchange_messages.cpp
@@ -286,19 +286,20 @@ bool Neutrals::pack_one_face(int iReceiver,
 }
 
 // -----------------------------------------------------------------------------
-// Pack one face for one variable
+// Pack one face for one variable - this is a generic code to pack one
+// variable one one face.
 // -----------------------------------------------------------------------------
 
 bool pack_one_var_on_one_face(arma_cube var_scgc,
-			      int iDirToPass,
-			      Grid &grid) {
-  
+                              int iDirToPass,
+                              Grid &grid) {
+
   static int nG = grid.get_nGCs();
   int iDir = grid.interchangesOneVar[iDirToPass].iFace;
   int iReceiver = grid.interchangesOneVar[iDirToPass].iProc_to;
   precision_t *buffer = grid.interchangesOneVar[iDirToPass].buffer;
   bool IsPole = grid.interchangesOneVar[iDirToPass].IsPole;
-    
+
   bool DidWork = true;
   int64_t iP;
 
@@ -706,7 +707,7 @@ bool Neutrals::exchange_old(Grid &grid) {
 // -----------------------------------------------------------------------------
 
 bool exchange_sides_init(Grid &grid, int64_t nVarsToPass) {
-  
+
   std::string function = "exchange_sides_init";
   static int iFunction = -1;
   report.enter(function, iFunction);
@@ -733,14 +734,14 @@ bool exchange_sides_init(Grid &grid, int64_t nVarsToPass) {
   }
 
   grid.interchangesOneVar.push_back(
-       grid.make_new_interconnection(0,
-				     nVarsToPass,
-				     grid.iProcXp,
-				     grid.edge_Xp,
-				     IsPole,
-				     ReverseX,
-				     ReverseY,
-				     XbecomesY));
+    grid.make_new_interconnection(0,
+                                  nVarsToPass,
+                                  grid.iProcXp,
+                                  grid.edge_Xp,
+                                  IsPole,
+                                  ReverseX,
+                                  ReverseY,
+                                  XbecomesY));
 
   // Message passing up:
   ReverseX = false;
@@ -770,14 +771,14 @@ bool exchange_sides_init(Grid &grid, int64_t nVarsToPass) {
   }
 
   grid.interchangesOneVar.push_back(
-       grid.make_new_interconnection(1,
-				     nVarsToPass,
-				     grid.iProcYp,
-				     grid.edge_Yp,
-				     IsPole,
-				     ReverseX,
-				     ReverseY,
-				     XbecomesY));
+    grid.make_new_interconnection(1,
+                                  nVarsToPass,
+                                  grid.iProcYp,
+                                  grid.edge_Yp,
+                                  IsPole,
+                                  ReverseX,
+                                  ReverseY,
+                                  XbecomesY));
 
   // Message passing left:
   ReverseX = false;
@@ -796,14 +797,14 @@ bool exchange_sides_init(Grid &grid, int64_t nVarsToPass) {
   }
 
   grid.interchangesOneVar.push_back(
-       grid.make_new_interconnection(2,
-				     nVarsToPass,
-				     grid.iProcXm,
-				     grid.edge_Xm,
-				     IsPole,
-				     ReverseX,
-				     ReverseY,
-				     XbecomesY));
+    grid.make_new_interconnection(2,
+                                  nVarsToPass,
+                                  grid.iProcXm,
+                                  grid.edge_Xm,
+                                  IsPole,
+                                  ReverseX,
+                                  ReverseY,
+                                  XbecomesY));
 
   // Message passing down:
   ReverseX = false;
@@ -833,14 +834,14 @@ bool exchange_sides_init(Grid &grid, int64_t nVarsToPass) {
   }
 
   grid.interchangesOneVar.push_back(
-       grid.make_new_interconnection(3,
-				     nVarsToPass,
-				     grid.iProcYm,
-				     grid.edge_Ym,
-				     IsPole,
-				     ReverseX,
-				     ReverseY,
-				     XbecomesY));
+    grid.make_new_interconnection(3,
+                                  nVarsToPass,
+                                  grid.iProcYm,
+                                  grid.edge_Ym,
+                                  IsPole,
+                                  ReverseX,
+                                  ReverseY,
+                                  XbecomesY));
 
   return DidWork;
 }
@@ -858,8 +859,8 @@ bool exchange_sides_init(Grid &grid, int64_t nVarsToPass) {
 // -----------------------------------------------------------------------------
 
 bool exchange_one_var(Grid &grid,
-		      arma_cube &var_to_pass,
-		      bool doReverseSignAcrossPole) {
+                      arma_cube &var_to_pass,
+                      bool doReverseSignAcrossPole) {
 
   std::string function = "exchange_one_var";
   static int iFunction = -1;
@@ -889,14 +890,15 @@ bool exchange_one_var(Grid &grid,
 
   int64_t iP;
   precision_t oneSign = 1.0;
-  
+
   for (int iDir = 0; iDir < 4; iDir++) {
     if (report.test_verbose(2))
       std::cout << "packing one var : " << iDir << " " << iProc
                 << " " << grid.interchangesOneVar[iDir].iProc_to
                 << " " << grid.interchangesOneVar[iDir].iTag << "\n";
+
     if (grid.interchangesOneVar[iDir].IsPole &&
-	doReverseSignAcrossPole)
+        doReverseSignAcrossPole)
       var_scgc = -1.0 * var_to_pass;
     else
       var_scgc = 1.0 * var_to_pass;
@@ -906,10 +908,10 @@ bool exchange_one_var(Grid &grid,
       iP = 0;
       report.print(2, "Packing Border");
       DidWork = pack_border(var_scgc,
-			    grid.interchangesOneVar[iDir].buffer,
-			    &iP,
-			    nG,
-			    iDir);
+                            grid.interchangesOneVar[iDir].buffer,
+                            &iP,
+                            nG,
+                            iDir);
       report.print(2, "Done Packing Border");
     }
   }
@@ -925,7 +927,7 @@ bool exchange_one_var(Grid &grid,
   // Receive all faces asynchronously:
   for (int iDir = 0; iDir < 4; iDir++) {
     if (grid.interchangesOneVar[iDir].iProc_to >= 0) {
-      report.print(2, "Receiving one face"); 
+      report.print(2, "Receiving one face");
       DidWork = grid.receive_one_var_one_face(iDir);
     }
   }
@@ -940,21 +942,27 @@ bool exchange_one_var(Grid &grid,
   for (int iDir = 0; iDir < 4; iDir++) {
     if (grid.interchangesOneVar[iDir].iProc_to >= 0) {
       iP = 0;
-      report.print(2, "Unpacking Border");      
+      report.print(2, "Unpacking Border");
       DidWork = unpack_border(var_to_pass,
                               grid.interchangesOneVar[iDir].rbuffer,
-			      &iP,
-			      nG,
-			      iDir,
-			      grid.interchangesOneVar[iDir].DoReverseX,
-			      grid.interchangesOneVar[iDir].DoReverseY,
-			      grid.interchangesOneVar[iDir].XbecomesY);
+                              &iP,
+                              nG,
+                              iDir,
+                              grid.interchangesOneVar[iDir].DoReverseX,
+                              grid.interchangesOneVar[iDir].DoReverseY,
+                              grid.interchangesOneVar[iDir].XbecomesY);
       report.print(2, "Done Unpacking Border");
     }
   }
 
   // Wait for all processors to be done.
   MPI_Barrier(aether_comm);
+
+  // If this is a cubesphere grid, interpolate ghostcells to their proper location
+  if (grid.IsCubeSphereGrid) {
+    var_scgc = interpolate_ghostcells(var_to_pass, grid);
+    var_to_pass = var_scgc;
+  }
 
   report.exit(function);
 
@@ -971,7 +979,7 @@ bool test_ghostcell_interpolation(Grid &grid) {
   report.enter(function, iFunction);
 
   bool didWork = true;
-  
+
   static int64_t iX, nX = grid.get_nX();
   static int64_t iY, nY = grid.get_nY();
   static int64_t iZ, nZ = grid.get_nZ();
@@ -984,82 +992,91 @@ bool test_ghostcell_interpolation(Grid &grid) {
   arma_cube lats = grid.geoLat_scgc * cRtoD;
   arma_cube lons = grid.geoLon_scgc * cRtoD;
 
+  arma_cube latsFixed = lats;
+  arma_cube lonsFixed = lons;
+
   // Set the ghostcells to 0:
   set_gcs_to_value(lats, 0.0, nG);
   set_gcs_to_value(lons, 0.0, nG);
-  
+
   // Message pass to get the lats and lons from the other faces
   report.print(1, "starting exchange to pass lats and lons");
   didWork = exchange_one_var(grid, lats, false);
   didWork = exchange_one_var(grid, lons, false);
-  
-  arma_cube latsFixed = interpolate_ghostcells(lats, grid);
-  arma_cube lonsFixed = interpolate_ghostcells(lons, grid);
 
   if (report.test_verbose(1)) {
-  
-  // Loop through the different directions:
-  for (iDir = 0; iDir < 4; iDir++) {
 
-    // Iteration indices - last point is <, so it is not included:
-    // Right:
-    if (iDir == 0) {
-      iStart = nX - nG;
-      iEnd = nX;
-      jStart = nG;
-      jEnd = nY - nG;
-    }
-    // Up:
-    if (iDir == 1) {
-      jStart = nY - nG;
-      jEnd = nY;
-      iStart = nG;
-      iEnd = nX - nG;
-    }
-    // Left:
-    if (iDir == 2) {
-      iStart = 0;
-      iEnd = nG;
-      jStart = nG;
-      jEnd = nY - nG;
-    }
-    // Down:
-    if (iDir == 3) {
-      jStart = 0;
-      jEnd = nG;
-      iStart = nG;
-      iEnd = nX - nG;
-    }
+    // Loop through the different directions:
+    for (iDir = 0; iDir < 4; iDir++) {
 
-    iZ = nG;
-    std::cout << "Looping through iDir = " << iDir << "\n";
-    for (iX = iStart; iX < iEnd; iX++) {
-      for (iY = jStart; iY < jEnd; iY++) {
+      // Iteration indices - last point is <, so it is not included:
+      // Right:
+      if (iDir == 0) {
+        iStart = nX - nG;
+        iEnd = nX;
+        jStart = nG;
+        jEnd = nY - nG;
+      }
 
-	std::cout << "iX, iY : " << iX << " " << iY << " ";
-	std::cout << " lats pre-inter : " << lats(iX, iY, iZ);
-	std::cout << " lats post-inter : " << latsFixed(iX, iY, iZ);
-	std::cout << " should be : " << grid.geoLat_scgc(iX, iY, iZ) * cRtoD;
-	if (!compare(latsFixed(iX, iY, iZ), grid.geoLat_scgc(iX, iY, iZ) * cRtoD)) {
-	  std::cout << " <-- lats don't match!!! ";
-	  didWork = false;
-	}
-	std::cout << "\n";
-	std::cout << "       lons pre-inter : " << lons(iX, iY, iZ);
-	std::cout << " lons post-inter : " << lonsFixed(iX, iY, iZ);
-	std::cout << " should be : " << grid.geoLon_scgc(iX, iY, iZ) * cRtoD;
-	if (!compare(lonsFixed(iX, iY, iZ), grid.geoLon_scgc(iX, iY, iZ) * cRtoD)) {
-	  std::cout << " <-- lons don't match!!! ";
-	  didWork = false;
-	}
-	std::cout << "\n";
+      // Up:
+      if (iDir == 1) {
+        jStart = nY - nG;
+        jEnd = nY;
+        iStart = nG;
+        iEnd = nX - nG;
+      }
+
+      // Left:
+      if (iDir == 2) {
+        iStart = 0;
+        iEnd = nG;
+        jStart = nG;
+        jEnd = nY - nG;
+      }
+
+      // Down:
+      if (iDir == 3) {
+        jStart = 0;
+        jEnd = nG;
+        iStart = nG;
+        iEnd = nX - nG;
+      }
+
+      iZ = nG;
+      std::cout << "Looping through iDir = " << iDir << "\n";
+
+      for (iX = iStart; iX < iEnd; iX++) {
+        for (iY = jStart; iY < jEnd; iY++) {
+
+          std::cout << "iX, iY : " << iX << " " << iY << " ";
+          std::cout << " lats pre-inter : " << lats(iX, iY, iZ);
+          std::cout << " lats post-inter : " << latsFixed(iX, iY, iZ);
+          std::cout << " should be : " << grid.geoLat_scgc(iX, iY, iZ) * cRtoD;
+
+          if (!compare(latsFixed(iX, iY, iZ), grid.geoLat_scgc(iX, iY, iZ) * cRtoD)) {
+            std::cout << " <-- lats don't match!!! ";
+            didWork = false;
+          }
+
+          std::cout << "\n";
+          std::cout << "       lons pre-inter : " << lons(iX, iY, iZ);
+          std::cout << " lons post-inter : " << lonsFixed(iX, iY, iZ);
+          std::cout << " should be : " << grid.geoLon_scgc(iX, iY, iZ) * cRtoD;
+
+          if (!compare(lonsFixed(iX, iY, iZ), grid.geoLon_scgc(iX, iY, iZ) * cRtoD)) {
+            std::cout << " <-- lons don't match!!! ";
+            didWork = false;
+          }
+
+          std::cout << "\n";
+        }
       }
     }
   }
-  }
+
   return didWork;
 }
-  
+
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
 
@@ -1070,14 +1087,14 @@ arma_cube interpolate_ghostcells(arma_cube varIn, Grid &grid) {
   report.enter(function, iFunction);
 
   bool didWork = true;
-  
+
   int64_t iDir;
   static int64_t iX, ix_, nX = grid.get_nX();
   static int64_t iY, iy_, nY = grid.get_nY();
   static int64_t iG, nG = grid.get_nGCs();
   precision_t r_;
   arma_cube varOut = varIn;
-  
+
   // Loop through the different directions:
   for (iDir = 0; iDir < 4; iDir++) {
 
@@ -1086,38 +1103,45 @@ arma_cube interpolate_ghostcells(arma_cube varIn, Grid &grid) {
 
       // Right and Left sides of the block
       if (iDir == 0 || iDir == 2) {
-	if (iDir == 0)
-	  iX = nX - 1 - iG;
-	if (iDir == 2)
-	  iX = iG;
-	for (iY = 0; iY < nY; iY++) {
-	  iy_ = grid.interchangesOneVar[iDir].index(iG, iY);
-	  r_ = grid.interchangesOneVar[iDir].ratio(iG, iY);
-	  if (iy_ > -1)
-	    varOut.tube(iX, iY) =
-	      (1.0 - r_) * varIn.tube(iX, iy_) + r_ * varIn.tube(iX, iy_ + 1);
-	}
+        if (iDir == 0)
+          iX = nX - 1 - iG;
+
+        if (iDir == 2)
+          iX = iG;
+
+        for (iY = 0; iY < nY; iY++) {
+          iy_ = grid.interchangesOneVar[iDir].index(iG, iY);
+          r_ = grid.interchangesOneVar[iDir].ratio(iG, iY);
+
+          if (iy_ > -1)
+            varOut.tube(iX, iY) =
+              (1.0 - r_) * varIn.tube(iX, iy_) + r_ * varIn.tube(iX, iy_ + 1);
+        }
       }
+
       // Up and Down sides of the block
       if (iDir == 1 || iDir == 3) {
-	if (iDir == 1)
-	  iY = nY - 1 - iG;
-	if (iDir == 3)
-	  iY = iG;
-	for (iX = 0; iX < nX; iX++) {
-	  ix_ = grid.interchangesOneVar[iDir].index(iG, iX);
-	  r_ = grid.interchangesOneVar[iDir].ratio(iG, iX);
-	  if (ix_ > -1)
-	    varOut.tube(iX, iY) =
-	      (1.0 - r_) * varIn.tube(ix_, iY) + r_ * varIn.tube(ix_ + 1, iY);
-	}
+        if (iDir == 1)
+          iY = nY - 1 - iG;
+
+        if (iDir == 3)
+          iY = iG;
+
+        for (iX = 0; iX < nX; iX++) {
+          ix_ = grid.interchangesOneVar[iDir].index(iG, iX);
+          r_ = grid.interchangesOneVar[iDir].ratio(iG, iX);
+
+          if (ix_ > -1)
+            varOut.tube(iX, iY) =
+              (1.0 - r_) * varIn.tube(ix_, iY) + r_ * varIn.tube(ix_ + 1, iY);
+        }
       }
     }
   }
-  
+
   return varOut;
 }
-  
+
 // -----------------------------------------------------------------------------
 // -----------------------------------------------------------------------------
 
@@ -1128,7 +1152,7 @@ bool find_ghostcell_interpolation_coefs(Grid &grid) {
   report.enter(function, iFunction);
 
   bool didWork = true;
-  
+
   static int64_t iX, nX = grid.get_nX();
   static int64_t iY, nY = grid.get_nY();
   static int64_t iZ, nZ = grid.get_nZ();
@@ -1141,20 +1165,21 @@ bool find_ghostcell_interpolation_coefs(Grid &grid) {
   arma_cube xLocal = grid.refx_angle * cRtoD;
 
   iZ = nG;
-  
+
   // Set the ghostcells to 0:
   set_gcs_to_value(yOther, 0.0, nG);
   set_gcs_to_value(xOther, 0.0, nG);
-  
+
   // Message pass to get the X and Y from the other faces
   report.print(1, "starting exchange to find interpolation indices");
   didWork = exchange_one_var(grid, yOther, false);
   didWork = exchange_one_var(grid, xOther, false);
-  
+
   report.print(1, "finished exchange");
 
   for (int64_t ip = 0; ip < 6; ip++) {
     MPI_Barrier(aether_comm);
+
     if (iProc == ip) {
       std::cout << "ip : " << ip << "\n";
       std::cout << "xLocal : \n" << xLocal.slice(iZ) << "\n";
@@ -1162,8 +1187,9 @@ bool find_ghostcell_interpolation_coefs(Grid &grid) {
     }
   }
 
-      
+
   MPI_Barrier(aether_comm);
+
   if (report.test_verbose(1)) {
     std::cout << "xLocal : \n" << xLocal.slice(iZ) << "\n";
     std::cout << "xOther : \n" << xOther.slice(iZ) << "\n";
@@ -1180,7 +1206,7 @@ bool find_ghostcell_interpolation_coefs(Grid &grid) {
   // These are just variables to make things easier to deal with:
   arma_vec ind, rat;
   arma_vec from, to;
-  
+
   // For the cubesphere, we can assume that we only need to do this
   // for one slice, since the angles are constant with altitude.
 
@@ -1196,74 +1222,84 @@ bool find_ghostcell_interpolation_coefs(Grid &grid) {
       //std::cout << "iG : " << iG << " " << iX << "\n";
 
       if (iDir == 0)
-	iX = nX - 1 - iG;
+        iX = nX - 1 - iG;
+
       if (iDir == 1)
-	iY = nY - 1 - iG;
+        iY = nY - 1 - iG;
+
       if (iDir == 2)
-	iX = iG;
+        iX = iG;
+
       if (iDir == 3)
-	iY = iG;
+        iY = iG;
 
       // From are the message passed ghost cells (wider),
       // To are the locations of the native grid (narrower)
       if (iDir == 0 || iDir == 2) {
-	// This is for right and left...
-	if (grid.interchangesOneVar[iDir].XbecomesY) {
-	  // moving from a row to a vector, so do a transpose:
-	  from = xOther.slice(iZ).row(iX).t();
-	} else
-	  from = yOther.slice(iZ).row(iX).t();
-	if (grid.interchangesOneVar[iDir].DoReverseY)
-	  from = reverse(from);
-	to = yLocal.slice(iZ).row(iX).t();
+        // This is for right and left...
+        if (grid.interchangesOneVar[iDir].XbecomesY) {
+          // moving from a row to a vector, so do a transpose:
+          from = xOther.slice(iZ).row(iX).t();
+        } else
+          from = yOther.slice(iZ).row(iX).t();
+
+        if (grid.interchangesOneVar[iDir].DoReverseY)
+          from = reverse(from);
+
+        to = yLocal.slice(iZ).row(iX).t();
       } else {
-	// This is for up and down...
-	if (grid.interchangesOneVar[iDir].XbecomesY) {
-	  // moving from a row to a vector, so do a transpose:
-	  from = yOther.slice(iZ).col(iY);
-	} else
-	  from = xOther.slice(iZ).col(iY);
-	if (grid.interchangesOneVar[iDir].DoReverseX)
-	  from = reverse(from);
-	to = xLocal.slice(iZ).col(iY);
+        // This is for up and down...
+        if (grid.interchangesOneVar[iDir].XbecomesY) {
+          // moving from a row to a vector, so do a transpose:
+          from = yOther.slice(iZ).col(iY);
+        } else
+          from = xOther.slice(iZ).col(iY);
+
+        if (grid.interchangesOneVar[iDir].DoReverseX)
+          from = reverse(from);
+
+        to = xLocal.slice(iZ).col(iY);
       }
+
       if (report.test_verbose(1)) {
-	std::cout << "iDir : " << iDir << "\n";
-	std::cout << "drx : " << grid.interchangesOneVar[iDir].DoReverseX <<"\n";
-	std::cout << "dry : " << grid.interchangesOneVar[iDir].DoReverseY <<"\n";
-	std::cout << "xby : " << grid.interchangesOneVar[iDir].XbecomesY <<"\n";
-	std::cout << "from : " << from.t();
-	std::cout << "to : " << to.t();
+        std::cout << "iDir : " << iDir << "\n";
+        std::cout << "drx : " << grid.interchangesOneVar[iDir].DoReverseX << "\n";
+        std::cout << "dry : " << grid.interchangesOneVar[iDir].DoReverseY << "\n";
+        std::cout << "xby : " << grid.interchangesOneVar[iDir].XbecomesY << "\n";
+        std::cout << "from : " << from.t();
+        std::cout << "to : " << to.t();
       }
+
       // This takes in vectors and returns them (ind and rat are vectors)
       didWork = find_interpolation_coefficients(from,
-						to,
-						ind,
-						rat);
+                                                to,
+                                                ind,
+                                                rat);
       grid.interchangesOneVar[iDir].index.row(iG) = ind.t();
       grid.interchangesOneVar[iDir].ratio.row(iG) = rat.t();
 
       if (report.test_verbose(3)) {
-	std::cout << "from :\n";
-	std::cout << from;
-	std::cout << "to :\n";
-	std::cout << to;
-	std::cout << "ind :\n";
-	std::cout << ind;
-	std::cout << "rat :\n";
-	std::cout << rat;
-	/*
-	  for (int64_t iY = nG; iY < nY - nG; iY++) {
-	  iy_ = grid.interchangesOneVar[iDir].index(iG, iY);
-	  r = grid.interchangesOneVar[iDir].ratio(iG, iY);
-	*/
+        std::cout << "from :\n";
+        std::cout << from;
+        std::cout << "to :\n";
+        std::cout << to;
+        std::cout << "ind :\n";
+        std::cout << ind;
+        std::cout << "rat :\n";
+        std::cout << rat;
+        /*
+          for (int64_t iY = nG; iY < nY - nG; iY++) {
+          iy_ = grid.interchangesOneVar[iDir].index(iG, iY);
+          r = grid.interchangesOneVar[iDir].ratio(iG, iY);
+        */
       }
     }
   }
+
   report.print(1, "finished compare");
 
   didWork = test_ghostcell_interpolation(grid);
-  
+
   // Wait for all processors to be done.
   MPI_Barrier(aether_comm);
 
@@ -1272,5 +1308,5 @@ bool find_ghostcell_interpolation_coefs(Grid &grid) {
   return didWork;
 }
 
-  
-  
+
+

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -26,6 +26,8 @@ Grid::Grid(int nX_in, int nY_in, int nZ_in, int nGCs_in) {
 
   refx_scgc.set_size(nX, nY, nZ);
   refy_scgc.set_size(nX, nY, nZ);
+  refx_angle.set_size(nX, nY, nZ);
+  refy_angle.set_size(nX, nY, nZ);
 
   A11_scgc.set_size(nX, nY, nZ);
   A12_scgc.set_size(nX, nY, nZ);

--- a/src/init_geo_grid.cpp
+++ b/src/init_geo_grid.cpp
@@ -135,6 +135,7 @@ void fill_cubesphere_lat_lon_from_norms(Quadtree quadtree,
       lat2d(iLR, iDU) = latp;
       lon2d(iLR, iDU) = lonp;
 
+      // refx and refy are the X, Y coordinates on the side of the CUBE
       // Identify sides, then apply correct transformation law
       // Face 1 to 4, equator faces with face 1 starting at the meridian
       // Face 5, North Pole (different from book def)
@@ -189,13 +190,16 @@ void transformation_metrics(Quadtree quadtree,
                             arma_mat &g12_upper,
                             arma_mat &g21_upper,
                             arma_mat &g22_upper,
-                            arma_mat &sqrt_g) {
+                            arma_mat &sqrt_g,
+			    arma_mat &refx_angle,
+			    arma_mat &refy_angle) {
+  
   int64_t nX = lat2d.n_rows;
   int64_t nY = lat2d.n_cols;
   // Assume R = 1 (since lat-lon/ xy generation assumes unit vect)
   double R = 1;
   double a = R / sqrt(3);
-  double xref, yref, rref;
+  double xref, yref, rref, xy;
   double latp, lonp;
   double g;
 
@@ -204,8 +208,13 @@ void transformation_metrics(Quadtree quadtree,
     for (int i = 0; i < nX; i++) {
       xref = refx(i, j);
       yref = refy(i, j);
+      xy = std::sqrt(xref * xref + yref * yref);
       rref = std::sqrt(xref * xref + yref * yref + a * a);
 
+      // Want to calculate angles based on x, y, z
+      refx_angle(i, j) = asin(xref/rref);
+      refy_angle(i, j) = asin(yref/rref);
+      
       latp = lat2d(i, j);
       lonp = lon2d(i, j);
 
@@ -358,15 +367,21 @@ void Grid::create_cubesphere_grid(Quadtree quadtree) {
   arma_mat g21_upper(nLons, nLats);
   arma_mat g22_upper(nLons, nLats);
   arma_mat sqrt_g(nLons, nLats);
+  arma_mat refx_angle_temp(nLons, nLats);
+  arma_mat refy_angle_temp(nLons, nLats);  
   fill_cubesphere_lat_lon_from_norms(quadtree, dr, du, ll, nGCs, 0.5, 0.5,
                                      lat2d, lon2d, refx, refy);
 
   transformation_metrics(quadtree, lat2d, lon2d, refx, refy,
                          A11, A12, A21, A22, A11_inv, A12_inv,
                          A21_inv, A22_inv, g11_upper, g12_upper,
-                         g21_upper, g22_upper, sqrt_g);
+                         g21_upper, g22_upper, sqrt_g,
+			 refx_angle_temp, refy_angle_temp);
 
   for (iAlt = 0; iAlt < nAlts; iAlt++) {
+    refx_angle.slice(iAlt) = refx_angle_temp;
+    refy_angle.slice(iAlt) = refy_angle_temp;
+  
     geoLon_scgc.slice(iAlt) = lon2d;
     geoLat_scgc.slice(iAlt) = lat2d;
     refx_scgc.slice(iAlt) = refx;
@@ -406,6 +421,8 @@ void Grid::create_cubesphere_grid(Quadtree quadtree) {
   arma_mat g21_upper_left(nLons + 1, nLats);
   arma_mat g22_upper_left(nLons + 1, nLats);
   arma_mat sqrt_g_left(nLons + 1, nLats);
+  arma_mat refx_angle_left_temp(nLons + 1, nLats);
+  arma_mat refy_angle_left_temp(nLons + 1, nLats);
   fill_cubesphere_lat_lon_from_norms(quadtree, dr, du, ll, nGCs, 0.0, 0.5,
                                      lat2d_left, lon2d_left,
                                      refx_left, refy_left);
@@ -417,7 +434,11 @@ void Grid::create_cubesphere_grid(Quadtree quadtree) {
                          A21_inv_left, A22_inv_left,
                          g11_upper_left, g12_upper_left,
                          g21_upper_left, g22_upper_left,
-                         sqrt_g_left);
+                         sqrt_g_left,
+			 refx_angle_left_temp, refy_angle_left_temp);
+  
+  refx_angle_Left = refx_angle_left_temp;
+  refy_angle_Left = refy_angle_left_temp;
 
   for (iAlt = 0; iAlt < nAlts; iAlt++) {
     geoLon_Left.slice(iAlt) = lon2d_left;
@@ -459,6 +480,8 @@ void Grid::create_cubesphere_grid(Quadtree quadtree) {
   arma_mat g21_upper_down(nLons, nLats + 1);
   arma_mat g22_upper_down(nLons, nLats + 1);
   arma_mat sqrt_g_down(nLons, nLats + 1);
+  arma_mat refx_angle_down_temp(nLons, nLats + 1);
+  arma_mat refy_angle_down_temp(nLons, nLats + 1);
 
   fill_cubesphere_lat_lon_from_norms(quadtree, dr, du, ll, nGCs, 0.5, 0.0,
                                      lat2d_down, lon2d_down,
@@ -471,7 +494,10 @@ void Grid::create_cubesphere_grid(Quadtree quadtree) {
                          A21_inv_down, A22_inv_down,
                          g11_upper_down, g12_upper_down,
                          g21_upper_down, g22_upper_down,
-                         sqrt_g_down);
+                         sqrt_g_down,
+			 refx_angle_down_temp, refy_angle_down_temp);
+  refx_angle_Down = refx_angle_down_temp;
+  refy_angle_Down = refy_angle_down_temp;
 
   for (iAlt = 0; iAlt < nAlts; iAlt++) {
     geoLon_Down.slice(iAlt) = lon2d_down;

--- a/src/init_geo_grid.cpp
+++ b/src/init_geo_grid.cpp
@@ -191,9 +191,9 @@ void transformation_metrics(Quadtree quadtree,
                             arma_mat &g21_upper,
                             arma_mat &g22_upper,
                             arma_mat &sqrt_g,
-			    arma_mat &refx_angle,
-			    arma_mat &refy_angle) {
-  
+                            arma_mat &refx_angle,
+                            arma_mat &refy_angle) {
+
   int64_t nX = lat2d.n_rows;
   int64_t nY = lat2d.n_cols;
   // Assume R = 1 (since lat-lon/ xy generation assumes unit vect)
@@ -212,9 +212,9 @@ void transformation_metrics(Quadtree quadtree,
       rref = std::sqrt(xref * xref + yref * yref + a * a);
 
       // Want to calculate angles based on x, y, z
-      refx_angle(i, j) = asin(xref/rref);
-      refy_angle(i, j) = asin(yref/rref);
-      
+      refx_angle(i, j) = asin(xref / rref);
+      refy_angle(i, j) = asin(yref / rref);
+
       latp = lat2d(i, j);
       lonp = lon2d(i, j);
 
@@ -368,7 +368,7 @@ void Grid::create_cubesphere_grid(Quadtree quadtree) {
   arma_mat g22_upper(nLons, nLats);
   arma_mat sqrt_g(nLons, nLats);
   arma_mat refx_angle_temp(nLons, nLats);
-  arma_mat refy_angle_temp(nLons, nLats);  
+  arma_mat refy_angle_temp(nLons, nLats);
   fill_cubesphere_lat_lon_from_norms(quadtree, dr, du, ll, nGCs, 0.5, 0.5,
                                      lat2d, lon2d, refx, refy);
 
@@ -376,12 +376,12 @@ void Grid::create_cubesphere_grid(Quadtree quadtree) {
                          A11, A12, A21, A22, A11_inv, A12_inv,
                          A21_inv, A22_inv, g11_upper, g12_upper,
                          g21_upper, g22_upper, sqrt_g,
-			 refx_angle_temp, refy_angle_temp);
+                         refx_angle_temp, refy_angle_temp);
 
   for (iAlt = 0; iAlt < nAlts; iAlt++) {
     refx_angle.slice(iAlt) = refx_angle_temp;
     refy_angle.slice(iAlt) = refy_angle_temp;
-  
+
     geoLon_scgc.slice(iAlt) = lon2d;
     geoLat_scgc.slice(iAlt) = lat2d;
     refx_scgc.slice(iAlt) = refx;
@@ -435,8 +435,8 @@ void Grid::create_cubesphere_grid(Quadtree quadtree) {
                          g11_upper_left, g12_upper_left,
                          g21_upper_left, g22_upper_left,
                          sqrt_g_left,
-			 refx_angle_left_temp, refy_angle_left_temp);
-  
+                         refx_angle_left_temp, refy_angle_left_temp);
+
   refx_angle_Left = refx_angle_left_temp;
   refy_angle_Left = refy_angle_left_temp;
 
@@ -495,7 +495,7 @@ void Grid::create_cubesphere_grid(Quadtree quadtree) {
                          g11_upper_down, g12_upper_down,
                          g21_upper_down, g22_upper_down,
                          sqrt_g_down,
-			 refx_angle_down_temp, refy_angle_down_temp);
+                         refx_angle_down_temp, refy_angle_down_temp);
   refx_angle_Down = refx_angle_down_temp;
   refy_angle_Down = refy_angle_down_temp;
 

--- a/src/inputs.cpp
+++ b/src/inputs.cpp
@@ -102,7 +102,7 @@ std::string dummy_string = "unknown";
 
 bool Inputs::check_settings(std::string key1,
                             std::string key2) {
-  if (report.test_verbose(1))
+  if (report.test_verbose(2))
     std::cout << "checking setting : "
               << key1 << " and "
               << key2 << "\n";
@@ -127,7 +127,7 @@ bool Inputs::check_settings(std::string key1,
 // 1 key:
 
 bool Inputs::check_settings(std::string key1) {
-  if (report.test_verbose(1))
+  if (report.test_verbose(2))
     std::cout << "checking setting : " << key1 << "\n";
 
   // try to find the keys first

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -77,6 +77,10 @@ int main() {
     if (!didWork)
       throw std::string("init_geo_grid failed!");  
 
+    // Find interpolation coefs for the ghostcells if cubesphere grid
+    didWork = find_ghostcell_interpolation_coefs(gGrid);
+
+    
     // Calculate centripetal acceleration, since this is a constant
     // vector on the grid:
     if (input.get_cent_acc())

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -296,7 +296,10 @@ bool output(const Neutrals &neutrals,
       if (type_output == "therm")
         filename = "3DTHR_";
 
-      filename = filename + time.get_YMD_HMS();
+      if ((int64_t(input.get_dt_output(iOutput)) % 60) == 0)
+        filename = filename + time.get_YMD_HM0();
+      else
+        filename = filename + time.get_YMD_HMS();
 
       if (nMembers > 1)
         filename = filename + "_" + cMember;

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -219,12 +219,12 @@ void Times::increment_time() {
   milli = iCurrent[6];
 
   char tmp[100];
-  sprintf(tmp, "%04d%02d%02d_%02d%02d%02d",
+  snprintf(tmp, 100, "%04d%02d%02d_%02d%02d%02d",
           year, month, day, hour, minute, second);
   sYMD_HMS = std::string(tmp);
-  sprintf(tmp, "%04d%02d%02d", year, month, day);
+  snprintf(tmp, 100, "%04d%02d%02d", year, month, day);
   sYMD = std::string(tmp);
-  sprintf(tmp, "%02d%02d%02d", hour, minute, second);
+  snprintf(tmp, 100, "%02d%02d%02d", hour, minute, second);
   sHMS = std::string(tmp);
 
   // Calculate Julian Day (day of year):

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -144,6 +144,15 @@ std::string Times::get_YMD_HMS() {
 }
 
 // -----------------------------------------------------------------------------
+// Get the current time as a string, with seconds as 00
+// -----------------------------------------------------------------------------
+
+std::string Times::get_YMD_HM0() {
+  return sYMD_HM0;
+}
+
+
+// -----------------------------------------------------------------------------
 // Get the intermediate stopping time
 // -----------------------------------------------------------------------------
 
@@ -222,6 +231,9 @@ void Times::increment_time() {
   snprintf(tmp, 100, "%04d%02d%02d_%02d%02d%02d",
            year, month, day, hour, minute, second);
   sYMD_HMS = std::string(tmp);
+  snprintf(tmp, 100, "%04d%02d%02d_%02d%02d%02d",
+           year, month, day, hour, minute, 0);
+  sYMD_HM0 = std::string(tmp);
   snprintf(tmp, 100, "%04d%02d%02d", year, month, day);
   sYMD = std::string(tmp);
   snprintf(tmp, 100, "%02d%02d%02d", hour, minute, second);

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -220,7 +220,7 @@ void Times::increment_time() {
 
   char tmp[100];
   snprintf(tmp, 100, "%04d%02d%02d_%02d%02d%02d",
-          year, month, day, hour, minute, second);
+           year, month, day, hour, minute, second);
   sYMD_HMS = std::string(tmp);
   snprintf(tmp, 100, "%04d%02d%02d", year, month, day);
   sYMD = std::string(tmp);

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -10,8 +10,8 @@
 // -----------------------------------------------------------------------------
 
 void set_gcs_to_value(arma_cube &var_scgc,
-		      precision_t value,
-		      int64_t nGCs) {
+                      precision_t value,
+                      int64_t nGCs) {
 
   std::string function = "set_gcs_to_value";
   static int iFunction = -1;
@@ -25,6 +25,7 @@ void set_gcs_to_value(arma_cube &var_scgc,
     var_scgc.slice(iZ).fill(value);
     var_scgc.slice(nZ - 1 - iZ).fill(value);
   }
+
   // bottom:
   var_scgc.tube(0, 0, nX - 1, nGCs - 1).fill(value);
   // top:
@@ -33,7 +34,7 @@ void set_gcs_to_value(arma_cube &var_scgc,
   var_scgc.tube(0, 0, nGCs - 1, nY - 1).fill(value);
   // right:
   var_scgc.tube(nX - nGCs, 0, nX - 1, nY - 1).fill(value);
-  
+
   report.exit(function);
   return;
 }
@@ -46,12 +47,12 @@ void set_gcs_to_value(arma_cube &var_scgc,
 // -----------------------------------------------------------------------------
 
 bool find_interpolation_coefficients(arma_vec inX,
-				     arma_vec outX,
-				     arma_vec &outIndex,
-				     arma_vec &outRatio) {
+                                     arma_vec outX,
+                                     arma_vec &outIndex,
+                                     arma_vec &outRatio) {
 
   bool didWork = true;
-  
+
   // Assume inX and outX are defined the same...
   int64_t iXo, iXi, nX = outX.n_rows;
 
@@ -59,27 +60,31 @@ bool find_interpolation_coefficients(arma_vec inX,
   outRatio.set_size(nX);
 
   bool isFound;
+
   for (iXo = 0; iXo < nX; iXo++) {
     iXi = 0;
     isFound = false;
+
     while (!isFound && iXi < nX - 1) {
       if (inX[iXi] <= outX[iXo] &&
-	  inX[iXi + 1] > outX[iXo])
-	isFound = true;
+          inX[iXi + 1] > outX[iXo])
+        isFound = true;
       else
-	iXi++;
+        iXi++;
     }
+
     if (isFound) {
       outIndex[iXo] = iXi;
       outRatio[iXo] =
-	(outX[iXo] - inX[iXi]) /
-	(inX[iXi + 1] - inX[iXi]);
+        (outX[iXo] - inX[iXi]) /
+        (inX[iXi + 1] - inX[iXi]);
     } else {
       didWork = false;
       outIndex[iXo] = -1;
       outRatio[iXo] = 0.0;
     }
   }
+
   return didWork;
 }
 
@@ -89,17 +94,20 @@ bool find_interpolation_coefficients(arma_vec inX,
 // -----------------------------------------------------------------------------
 
 arma_vec interpolate1d(arma_vec inY,
-		       arma_vec &index,
-		       arma_vec &ratio) {
+                       arma_vec &index,
+                       arma_vec &ratio) {
   int64_t iY, iy_, nY = inY.n_rows;
   precision_t r_;
   arma_vec outY(nY);
+
   for (iY = 0; iY < nY; iY++) {
     iy_ = index(iY);
     r_ = ratio(iY);
+
     if (iy_ > -1)
       outY(iY) = (1.0 - r_) * inY(iy_) + r_ * inY(iy_);
   }
+
   return outY;
 }
 

--- a/srcPython/postAether.py
+++ b/srcPython/postAether.py
@@ -444,7 +444,7 @@ def parse_args():
     parser.add_argument('-rm', \
                         help='removes processed files', \
                         action="store_true")
-    parser.add_argument('-alt', default = 2, type = int, \
+    parser.add_argument('-alt', default = -1, type = int, \
                         help='altitude to plot (-1 for no plot!)')
     parser.add_argument('-v', \
                         help='turn on verbose mode', \
@@ -463,11 +463,11 @@ def get_core_file(filename):
     isEnsemble = False
     ensembleFile = ''
     ensembleNumber = -1
-    m = re.match('.*([0123]D.*)(_g\d*)(\..*)',filename)
+    m = re.match(r'.*([0123]D.*)(_g[0-9]*)(\..*)',filename)
     if m:
         coreFile = m.group(1)
         # check if file is a member of an ensemble:
-        check = re.match('.*([0123]D.*)(_m)(\d*)',coreFile)
+        check = re.match('.*([0123]D.*)(_m)([0-9]*)',coreFile)
         if (check):
             ensembleFile = check.group(1)
             isEnsemble = True
@@ -934,7 +934,7 @@ def write_and_plot_data(dataToWrite,
         print('  --> Outputting hdf5 file : ', hdf5File)
         write_hdf5(dataToWrite, hdf5File, isVerbose = isVerbose)
 
-    if (iAlt > -1):
+    if ((iAlt > -1) & (len(dataToWrite) > 1)):
         plotFile = fileStart + fileAddon + '.png'
         var = dataToWrite[0]['vars'][iVar]
         plot_all_blocks(dataToWrite, var, iAlt, plotFile)


### PR DESCRIPTION
# Description

In the cubesphere grid, the ghostcells don't line up when they go on to a different face.  The old way of dealing with this was to put the ghostcells at the location of the cells on the other face.  This does not work for the gradient calculator or the advection scheme, which assumes that the cells all line up along constant lines, and can be projected onto the same flat cube face.  So, instead, the cells from the other face are interpolated to the location of the ghostcells on the current face.  This seems to work for some faces, but doesn't seem to be exact.  This needs to be investigated more at a later time.

## Type of change

- Bug fix - in order to work with the gradient calculator and advection scheme, this needed to be fixed. 

# How Has This Been Tested?

The latitude and longitude are message passed in the test and are verified to be in the same location in the ghostcells.

## Test configuration

* Operating system: Mac OSX 13.6
* Compiler, version number: gcc version 13.2

# Checklist:

- [N/A] Make sure you are merging into the ``develop`` (not ``master``) branch
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [N/A] Add a note to ``CHANGELOG.md``, summarizing the changes
