### PR TITLE
Restart fix

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -111,4 +111,4 @@ cd run.test
 The output should LOOK LIKE THIS
 
 For more details about running Aether, see the documentation about creating and
-modifying input files HERE.
+modifying input files in the document running_aether.md.

--- a/include/output.h
+++ b/include/output.h
@@ -133,7 +133,12 @@ class OutputContainer {
      \brief write a binary file with the information in the container
    **/
   bool write_container_binary();
-  
+
+  /**********************************************************************
+     \brief read a binary file with the information into a container
+   **/
+  bool read_container_binary();
+
   /**********************************************************************
      \brief write a netcdf file with the information in the container
    **/
@@ -142,7 +147,7 @@ class OutputContainer {
   /**********************************************************************
      \brief read from a file an load into the container
    **/
-  void read();
+  bool read();
   
   /**********************************************************************
      \brief display information contained in the container
@@ -152,7 +157,7 @@ class OutputContainer {
   /**********************************************************************
      \brief read a netcdf file - put the information in the container
    **/
-  int read_container_netcdf();
+  bool read_container_netcdf();
   
   /**********************************************************************
      \brief clears the vector of variables 

--- a/include/times.h
+++ b/include/times.h
@@ -83,6 +83,11 @@ public:
   double get_current();
 
   /**************************************************************
+     \brief Sets the start time at the start of the time loop
+   **/
+  void set_start_time_loop();
+
+  /**************************************************************
      \brief Returns the end time in seconds since ref date
    **/
   double get_end();
@@ -236,6 +241,9 @@ private:
 
   /// This is the system time at the start of the simulation
   time_t sys_time_start;
+
+  /// This is the system time at the start of time loop
+  time_t sys_time_start_time_loop;
 
   /// This is the current system time of the simulation
   time_t sys_time_current;

--- a/share/run/UA/inputs/defaults.json
+++ b/share/run/UA/inputs/defaults.json
@@ -114,8 +114,8 @@
 	"species" : ["O2", "O2+"]},
 
     "Outputs" : {
-	"type" : ["neutrals"],
-	"dt" : [900, 0.0]},
+	"type" : ["states", "grid"],
+	"dt" : [900, -1]},
 
     "Restart" : {
 	"do" : false,

--- a/src/containers_io.cpp
+++ b/src/containers_io.cpp
@@ -1,0 +1,440 @@
+// Copyright 2020, the Aether Development Team (see doc/dev_team.md for members)
+// Full license can be found in License.md
+
+#include "aether.h"
+
+/* ---------------------------------------------------------------------
+
+   General Methods for the output containers
+
+ -------------------------------------------------------------------- */
+
+// -----------------------------------------------------------------------------
+// gets the number of elements in the output container
+// -----------------------------------------------------------------------------
+
+int64_t OutputContainer::get_nElements() {
+  return elements.size();
+}
+
+// -----------------------------------------------------------------------------
+// gets the ith element arma_cube in the output container
+// -----------------------------------------------------------------------------
+
+arma_cube OutputContainer::get_element_value(int64_t iElement) {
+  arma_cube val;
+
+  if (iElement < elements.size())
+    val = elements[iElement].value;
+
+  return val;
+}
+
+// -----------------------------------------------------------------------------
+// gets the element arma_cube in the output container given name
+// -----------------------------------------------------------------------------
+
+arma_cube OutputContainer::get_element_value(std::string var_to_get) {
+  arma_cube val;
+  int64_t iElement = find_element(var_to_get);
+
+  if (iElement >= 0)
+    val = elements[iElement].value;
+
+  return val;
+}
+
+// -----------------------------------------------------------------------------
+// gets the ith element name in the output container
+// -----------------------------------------------------------------------------
+
+std::string OutputContainer::get_element_name(int64_t iElement) {
+  std::string val = "";
+
+  if (iElement < elements.size())
+    val = elements[iElement].cName;
+
+  return val;
+}
+
+// -----------------------------------------------------------------------------
+// find the element number for the given variable name
+// -----------------------------------------------------------------------------
+
+int64_t OutputContainer::find_element(std::string var_to_find) {
+  int64_t nVars = elements.size();
+  int64_t iVarSave = -1;
+
+  for (int64_t iVar = 0; iVar < nVars; iVar++)
+    if (elements[iVar].cName.compare(var_to_find) == 0)
+      iVarSave = iVar;
+
+  return iVarSave;
+}
+
+// -----------------------------------------------------------------------------
+// sets the output type to be binary
+// -----------------------------------------------------------------------------
+
+void OutputContainer::set_binary() {
+  output_type = binary_type;
+}
+
+// -----------------------------------------------------------------------------
+// sets the output type to be netcdf
+// -----------------------------------------------------------------------------
+
+void OutputContainer::set_netcdf() {
+  output_type = netcdf_type;
+}
+
+// -----------------------------------------------------------------------------
+// sets the output type to be hdf5
+// -----------------------------------------------------------------------------
+
+void OutputContainer::set_hdf5() {
+  output_type = hdf5_type;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+
+void OutputContainer::set_directory(std::string in_dir) {
+  directory = in_dir;
+}
+
+// -----------------------------------------------------------------------------
+// Set the filename for file output.  We can increase the
+// sophistication of this system by adding on the timestamp.
+// -----------------------------------------------------------------------------
+
+void OutputContainer::set_filename(std::string in_filename) {
+  filename = in_filename;
+}
+
+// -----------------------------------------------------------------------------
+// Store variable information into the output container
+// -----------------------------------------------------------------------------
+
+void OutputContainer::store_variable(std::string name,
+                                     std::string unit,
+                                     arma_cube value) {
+  var_struct single;
+  single.cName = name;
+  single.cLongName = "";
+  single.cUnit = unit;
+  single.value = value;
+  elements.push_back(single);
+}
+
+// -----------------------------------------------------------------------------
+// Store variable information into the output container
+//   - add long_name (needed for netcdf standardization)
+// -----------------------------------------------------------------------------
+
+void OutputContainer::store_variable(std::string name,
+                                     std::string long_name,
+                                     std::string unit,
+                                     arma_cube value) {
+  var_struct single;
+  single.cName = name;
+  single.cLongName = long_name;
+  single.cUnit = unit;
+  single.value = value;
+  elements.push_back(single);
+}
+
+// -----------------------------------------------------------------------------
+// Set the time of the output file
+// -----------------------------------------------------------------------------
+
+void OutputContainer::set_time(double time) {
+  itime = time_real_to_int(time);
+}
+
+// -----------------------------------------------------------------------------
+// Set the version number of the output. This, in theory, should be
+// the version of Aether.
+// -----------------------------------------------------------------------------
+
+void OutputContainer::set_version(float in_version) {
+  version = in_version;
+}
+
+// -----------------------------------------------------------------------------
+// Clears the elements vector within the output container
+// -----------------------------------------------------------------------------
+
+void OutputContainer::clear_variables() {
+  elements.clear();
+}
+
+// -----------------------------------------------------------------------------
+// Initialize the output container
+// -----------------------------------------------------------------------------
+
+OutputContainer::OutputContainer() {
+  // Set default output type to netCDF
+#ifdef NETCDF
+  output_type = netcdf_type;
+#else
+  output_type = binary_type;
+#endif
+}
+
+// -----------------------------------------------------------------------------
+// This is the write method. Here we look at which type of file output
+// the user wants, and then output that particular type.
+// -----------------------------------------------------------------------------
+
+bool OutputContainer::write() {
+
+  bool didWork = true;
+
+  if (output_type == binary_type) {
+    didWork = write_container_header();
+
+    if (didWork)
+      didWork = write_container_binary();
+  }
+
+  if (output_type == netcdf_type)
+    didWork = write_container_netcdf();
+
+  return didWork;
+}
+
+// -----------------------------------------------------------------------------
+// This is the read method. Here we look at which type of file output
+// the user wants, and then read that particular type.
+// -----------------------------------------------------------------------------
+
+bool OutputContainer::read() {
+
+    bool didWork = true;
+
+    if (output_type == binary_type)
+        didWork = read_container_binary();
+
+    if (output_type == netcdf_type)
+        didWork = read_container_netcdf();
+
+    return didWork;
+}
+
+
+
+// -----------------------------------------------------------------------------
+// display the contents of an output container to the screen
+// -----------------------------------------------------------------------------
+
+void OutputContainer::display() {
+  std::cout << "Displaying Container Information:\n";
+  std::cout << "  time : ";
+  display_itime(itime);
+  std::cout << "  nX : " << elements[0].value.n_rows << "\n";
+  std::cout << "  nY : " << elements[0].value.n_cols << "\n";
+  std::cout << "  nZ : " << elements[0].value.n_slices << "\n";
+  int64_t nVars = elements.size();
+  std::cout << "  Number of Variables : " << nVars << "\n";
+
+  for (int64_t iVar = 0; iVar < nVars; iVar++) {
+    std::cout << "  Variable " << iVar << ": " << elements[iVar].cName << "\n";
+    std::cout << "      Unit  : " << elements[iVar].cUnit << "\n";
+
+    if (elements[iVar].cLongName.length() > 0)
+      std::cout << "      Long Name  : " << elements[iVar].cLongName;
+  }
+}
+
+/* ---------------------------------------------------------------------
+
+   Output methods for binary files
+
+ -------------------------------------------------------------------- */
+
+// -----------------------------------------------------------------------------
+// Write a header file for the container.  This outputs into a json
+// formatted file.
+// -----------------------------------------------------------------------------
+
+bool OutputContainer::write_container_header() {
+
+  bool didWork = true;
+  int64_t nVars = elements.size();
+  int64_t nX = elements[0].value.n_rows;
+  int64_t nY = elements[0].value.n_cols;
+  int64_t nZ = elements[0].value.n_slices;
+
+  std::vector<std::string> variables;
+  std::vector<std::string> units;
+
+  for (int64_t iVar = 0; iVar < nVars; iVar++) {
+    variables.push_back(elements[iVar].cName);
+    units.push_back(elements[iVar].cUnit);
+  }
+
+  json header = json::object({ {"version", version},
+    {"time", itime},
+    {"nVars", nVars},
+    {"nX", nX},
+    {"nY", nY},
+    {"nZ", nZ},
+    {"nLons", nX},
+    {"nLats", nY},
+    {"nAlts", nZ},
+    {"variables", variables},
+    {"units", units} });
+  std::string whole_filename = directory + "/" + filename + ".json";
+
+  try {
+    std::ofstream file(whole_filename);
+    file << header.dump(4) << "\n";
+    file.close();
+  } catch (...) {
+    report.error("Error writing header file : " + whole_filename);
+    didWork = false;
+  }
+
+  return didWork;
+}
+
+// -----------------------------------------------------------------------------
+// Write a header file for the container.  This outputs into a json
+// formatted file.
+// -----------------------------------------------------------------------------
+
+bool OutputContainer::read_container_binary() {
+
+    std::string function = "OutputContainer::read_container_binary";
+    static int iFunction = -1;
+    report.enter(function, iFunction);
+
+    bool didWork = true;
+    std::string bin_filename = directory + "/" + filename + ".bin";
+    std::string json_filename = directory + "/" + filename + ".json";
+
+    json header = read_json(json_filename);
+
+    if (report.test_verbose(2)) {
+        std::cout << "reading binary restart\n --> json header is here:\n";
+        std::cout << std::setw(2) << header;
+    }
+
+    int64_t iVar, nVars = header["nVars"];
+    int64_t iX, nX = header["nX"];
+    int64_t iY, nY = header["nY"];
+    int64_t iZ, nZ = header["nZ"];
+    int64_t iTotalSize = nX * nY * nZ;
+
+    float *variable_array = new float[iTotalSize];
+    arma_cube value_scgc;
+    value_scgc.set_size(nX, nY, nZ);
+    int64_t index;
+
+    std::ifstream binary;
+    binary.open(bin_filename, ios::binary | ios::in);
+
+    // Now, read and store variable-by-variable
+
+    for (iVar = 0; iVar < nVars; iVar++) {
+
+        // Read from the binary file
+        binary.read((char *) variable_array, iTotalSize * sizeof(float));
+
+        for (iZ = 0; iZ < nZ; iZ++) {
+            for (iY = 0; iY < nY; iY++) {
+                for (iX = 0; iX < nX; iX++) {
+                    // Python ordering!
+                    index = iX + iY * nX + iZ * nY * nX;
+                    value_scgc(iX, iY, iZ) = variable_array[index];
+                }
+            }
+        }
+
+        // Store in the container:
+        if (report.test_verbose(2)) {
+            std::cout << "Storing Variable : ";
+            std::cout << header["variables"][iVar] << " : " << value_scgc(int(nX/2), int(nY/2), int(nZ/2)) << "\n";
+        }
+
+        store_variable(header["variables"][iVar], header["units"][iVar], value_scgc);
+    }
+    report.exit(function);
+    return didWork;
+}
+
+//----------------------------------------------------------------------
+// Output a given arma_cube to the binary file.
+// ----------------------------------------------------------------------
+
+void output_binary_3d(std::ofstream &binary,
+                      arma_cube value) {
+
+  // Get the size of the cube:
+
+  int64_t nX = value.n_rows;
+  int64_t nY = value.n_cols;
+  int64_t nZ = value.n_slices;
+  int64_t iX, iY, iZ, index;
+
+  int64_t nPts = nX * nY * nZ;
+  int64_t iTotalSize = nPts * sizeof(float);
+
+  // Create a temporary c-array to use to output the variable
+  float *tmp_s3gc = static_cast<float*>(malloc(iTotalSize));
+
+  // Move the data from the cube to the c-array
+
+  for (iZ = 0; iZ < nZ; iZ++) {
+    for (iY = 0; iY < nY; iY++) {
+      for (iX = 0; iX < nX; iX++) {
+        // Python ordering!
+        index = iX + iY * nX + iZ * nY * nX;
+        tmp_s3gc[index] = value(iX, iY, iZ);
+      }
+    }
+  }
+
+  // Output the data to the binary file
+  binary.write((char *) tmp_s3gc, iTotalSize);
+
+  // delete the c-array
+  free(tmp_s3gc);
+}
+
+// -----------------------------------------------------------------------------
+// dump the contents of the container out into a binary file
+// -----------------------------------------------------------------------------
+
+bool OutputContainer::write_container_binary() {
+
+  bool didWork = true;
+  std::ofstream binary;
+  std::string whole_filename = directory + "/" + filename + ".bin";
+
+  try {
+    binary.open(whole_filename, ios::binary | ios::out);
+
+    int64_t nVars = elements.size();
+
+    for (int64_t iVar = 0; iVar < nVars; iVar++)
+      output_binary_3d(binary, elements[iVar].value);
+
+    return didWork;
+  } catch (...) {
+    report.error("Error writing binary file : " + whole_filename);
+    didWork = false;
+  }
+
+  return didWork;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------

--- a/src/exchange_messages.cpp
+++ b/src/exchange_messages.cpp
@@ -30,7 +30,7 @@
 
 // -----------------------------------------------------------------------------
 // This is the main exchange messages for the neutrals.
-//   We are exchanging densities, temperatures, and velocities   
+//   We are exchanging densities, temperatures, and velocities
 // -----------------------------------------------------------------------------
 
 
@@ -1116,6 +1116,7 @@ bool test_ghostcell_interpolation(Grid &grid) {
       }
     }
   }
+
   report.exit(function);
   return didWork;
 }

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -258,18 +258,18 @@ bool Grid::read_restart(std::string dir) {
     RestartContainer.set_version(0.1);
     // Cell Centers:
     RestartContainer.set_filename("grid_" + cGrid);
-    RestartContainer.read_container_netcdf();
+    RestartContainer.read();
     geoLon_scgc = RestartContainer.get_element_value(longitude_name);
     geoLat_scgc = RestartContainer.get_element_value(latitude_name);
     geoAlt_scgc = RestartContainer.get_element_value(altitude_name);
     // Down Edges:
     RestartContainer.set_filename("grid_below_" + cGrid);
-    RestartContainer.read_container_netcdf();
+    RestartContainer.read();
     geoAlt_Below = RestartContainer.get_element_value(altitude_name +
                                                       " Below");
     // Cell Corners:
     RestartContainer.set_filename("grid_corners_" + cGrid);
-    RestartContainer.read_container_netcdf();
+    RestartContainer.read();
     geoLon_Corner = RestartContainer.get_element_value(longitude_name +
                                                        " Corners");
     geoLat_Corner = RestartContainer.get_element_value(latitude_name +
@@ -278,14 +278,14 @@ bool Grid::read_restart(std::string dir) {
                                                        " Corners");
     // Left Edges:
     RestartContainer.set_filename("grid_left_" + cGrid);
-    RestartContainer.read_container_netcdf();
+    RestartContainer.read();
     geoLon_Left = RestartContainer.get_element_value(longitude_name +
                                                      " Left");
     geoLat_Left = RestartContainer.get_element_value(latitude_name +
                                                      " Left");
     // Down Edges:
     RestartContainer.set_filename("grid_down_" + cGrid);
-    RestartContainer.read_container_netcdf();
+    RestartContainer.read();
     geoLon_Down = RestartContainer.get_element_value(longitude_name +
                                                      " Down");
     geoLat_Down = RestartContainer.get_element_value(latitude_name +

--- a/src/init_geo_grid.cpp
+++ b/src/init_geo_grid.cpp
@@ -907,19 +907,6 @@ void Grid::correct_xy_grid(Planets planet) {
     precision_t R = R_Alts(iAlt);
     refx_scgc.slice(iAlt) *= R;
     refy_scgc.slice(iAlt) *= R;
-    //A11_scgc.slice(iAlt) *= R;
-    //A12_scgc.slice(iAlt) *= R;
-    //A21_scgc.slice(iAlt) *= R;
-    //A22_scgc.slice(iAlt) *= R;
-    //A11_inv_scgc.slice(iAlt) /= R;
-    //A12_inv_scgc.slice(iAlt) /= R;
-    //A21_inv_scgc.slice(iAlt) /= R;
-    //A22_inv_scgc.slice(iAlt) /= R;
-    //g11_upper_scgc.slice(iAlt) /= R * R;
-    //g12_upper_scgc.slice(iAlt) /= R * R;
-    //g21_upper_scgc.slice(iAlt) /= R * R;
-    //g22_upper_scgc.slice(iAlt) /= R * R;
-    //sqrt_g_scgc.slice(iAlt) *= R * R;
 
     // Addition: Get a copy of dx dy
     arma_mat curr_refx = refx_scgc.slice(iAlt);
@@ -930,36 +917,8 @@ void Grid::correct_xy_grid(Planets planet) {
 
     refx_Left.slice(iAlt) *= R;
     refy_Left.slice(iAlt) *= R;
-    //A11_Left.slice(iAlt) *= R;
-    //A12_Left.slice(iAlt) *= R;
-    //A21_Left.slice(iAlt) *= R;
-    //A22_Left.slice(iAlt) *= R;
-    //A11_inv_Left.slice(iAlt) /= R;
-    //A12_inv_Left.slice(iAlt) /= R;
-    //A21_inv_Left.slice(iAlt) /= R;
-    //A22_inv_Left.slice(iAlt) /= R;
-    //g11_upper_Left.slice(iAlt) /= R * R;
-    //g12_upper_Left.slice(iAlt) /= R * R;
-    //g21_upper_Left.slice(iAlt) /= R * R;
-    //g22_upper_Left.slice(iAlt) /= R * R;
-    //sqrt_g_Left.slice(iAlt) *= R * R;
-
     refx_Down.slice(iAlt) *= R;
     refy_Down.slice(iAlt) *= R;
-    //A11_Down.slice(iAlt) *= R;
-    //A12_Down.slice(iAlt) *= R;
-    //A21_Down.slice(iAlt) *= R;
-    //A22_Down.slice(iAlt) *= R;
-    //A11_inv_Down.slice(iAlt) /= R;
-    //A12_inv_Down.slice(iAlt) /= R;
-    //A21_inv_Down.slice(iAlt) /= R;
-    //A22_inv_Down.slice(iAlt) /= R;
-    //g11_upper_Down.slice(iAlt) /= R * R;
-    //g12_upper_Down.slice(iAlt) /= R * R;
-    //g21_upper_Down.slice(iAlt) /= R * R;
-    //g22_upper_Down.slice(iAlt) /= R * R;
-    //sqrt_g_Down.slice(iAlt) *= R * R;
-
     refx_Corner.slice(iAlt) *= R;
     refy_Corner.slice(iAlt) *= R;
   }
@@ -991,13 +950,15 @@ bool Grid::init_geo_grid(Quadtree quadtree,
   else
     create_sphere_connection(quadtree);
 
-  if (input.get_do_restart()) {
+  if (input.get_do_restart() & !input.get_is_cubesphere()) {
     report.print(1, "Restarting! Reading grid files!");
     DidWork = read_restart(input.get_restartin_dir());
   } else {
-    if (input.get_is_cubesphere())
+    if (input.get_is_cubesphere()) {
+      if (input.get_do_restart()) 
+        report.print(0, "Not restarting the grid - it is too complicated!");
       create_cubesphere_grid(quadtree);
-    else
+    } else
       create_sphere_grid(quadtree);
 
     MPI_Barrier(aether_comm);

--- a/src/init_geo_grid.cpp
+++ b/src/init_geo_grid.cpp
@@ -955,8 +955,9 @@ bool Grid::init_geo_grid(Quadtree quadtree,
     DidWork = read_restart(input.get_restartin_dir());
   } else {
     if (input.get_is_cubesphere()) {
-      if (input.get_do_restart()) 
+      if (input.get_do_restart())
         report.print(0, "Not restarting the grid - it is too complicated!");
+
       create_cubesphere_grid(quadtree);
     } else
       create_sphere_grid(quadtree);

--- a/src/ions.cpp
+++ b/src/ions.cpp
@@ -301,7 +301,7 @@ bool Ions::restart_file(std::string dir, bool DoRead) {
 
   try {
     if (DoRead)
-      RestartContainer.read_container_netcdf();
+      RestartContainer.read();
     else {
       RestartContainer.set_version(0.1);
       RestartContainer.set_time(0.0);

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -24,35 +24,41 @@ int main() {
   try {
     // Create inputs (reading the input file):
     input = Inputs(time);
+
     if (!input.is_ok())
       throw std::string("input initialization failed!");
 
     if (input.get_is_student())
       report.print(-1, "Hello " +
-		   input.get_student_name() + " - welcome to Aether!");
+                   input.get_student_name() + " - welcome to Aether!");
 
     Quadtree quadtree;
+
     if (!quadtree.is_ok())
       throw std::string("quadtree initialization failed!");
-    
+
     // Initialize MPI and parallel aspects of the code:
     didWork = init_parallel(quadtree);
+
     if (!didWork)
       throw std::string("init_parallel failed!");
 
     // Everything should be set for the inputs now, so write a restart file:
     didWork = input.write_restart();
+
     if (!didWork)
       throw std::string("input.write_restart failed!");
 
     // Initialize the EUV system:
     Euv euv;
+
     if (!euv.is_ok())
       throw std::string("EUV initialization failed!");
 
     // Initialize the planet:
     Planets planet;
     MPI_Barrier(aether_comm);
+
     if (!planet.is_ok())
       throw std::string("planet initialization failed!");
 
@@ -60,27 +66,28 @@ int main() {
     Indices indices;
     didWork = read_and_store_indices(indices);
     MPI_Barrier(aether_comm);
+
     if (!didWork)
       throw std::string("read_and_store_indices failed!");
-    
+
     // Perturb the inputs if user has asked for this
     indices.perturb();
     MPI_Barrier(aether_comm);
-    
+
     // Initialize Geographic grid:
     Grid gGrid(input.get_nLonsGeo(),
-	       input.get_nLatsGeo(),
-	       input.get_nAltsGeo(),
-	       nGeoGhosts);
+               input.get_nLatsGeo(),
+               input.get_nAltsGeo(),
+               nGeoGhosts);
     didWork = gGrid.init_geo_grid(quadtree, planet);
     MPI_Barrier(aether_comm);
+
     if (!didWork)
-      throw std::string("init_geo_grid failed!");  
+      throw std::string("init_geo_grid failed!");
 
     // Find interpolation coefs for the ghostcells if cubesphere grid
     didWork = find_ghostcell_interpolation_coefs(gGrid);
 
-    
     // Calculate centripetal acceleration, since this is a constant
     // vector on the grid:
     if (input.get_cent_acc())
@@ -100,7 +107,7 @@ int main() {
     // Is simply adds nans and infinities in a few places, then
     // checks for them to make sure the checking is working
     // -----------------------------------------------------------------
-    
+
     if (input.get_nan_test()) {
       neutrals.nan_test(input.get_nan_test_variable());
       ions.nan_test(input.get_nan_test_variable());
@@ -128,6 +135,7 @@ int main() {
     // Initialize electrodynamics and check if electrodynamics times
     // works with input time
     Electrodynamics electrodynamics(time);
+
     if (!electrodynamics.is_ok())
       throw std::string("electrodynamics initialization failed!");
 
@@ -135,15 +143,17 @@ int main() {
     if (input.get_do_restart()) {
       report.print(1, "Restarting! Reading time file!");
       didWork = time.restart_file(input.get_restartin_dir(), DoRead);
+
       if (!didWork)
-	throw std::string("Reading Restart for time Failed!!!\n");
+        throw std::string("Reading Restart for time Failed!!!\n");
     }
 
     // This is for the initial output.  If it is not a restart, this will go:
     if (time.check_time_gate(input.get_dt_output(0)))
       didWork = output(neutrals, ions, gGrid, time, planet);
+
     if (!didWork)
-      throw std::string("output failed!");  
+      throw std::string("output failed!");
 
     // This is advancing now... We are not coupling, so set dt_couple to the
     // end of the simulation
@@ -158,26 +168,30 @@ int main() {
     // be made into a library and run externally.
 
     Logfile logfile(indices);
+
+    time.set_start_time_loop();
+
     while (time.get_current() < time.get_end()) {
 
       time.increment_intermediate(dt_couple);
 
       // Increment until the intermediate time:
       while (time.get_current() < time.get_intermediate()) {
-	didWork = advance(planet,
-			  gGrid,
-			  time,
-			  euv,
-			  neutrals,
-			  ions,
-			  chemistry,
-			  electrodynamics,
-			  indices,
-			  logfile);
-	if (!didWork)
-	  throw std::string("Error in advance!");  
+        didWork = advance(planet,
+                          gGrid,
+                          time,
+                          euv,
+                          neutrals,
+                          ions,
+                          chemistry,
+                          electrodynamics,
+                          indices,
+                          logfile);
+
+        if (!didWork)
+          throw std::string("Error in advance!");
       }
-      
+
       // Should write out some restart files every time we are done with
       // intermediate times.  Just so when we restart, we know that we can
       // couple first thing and everything should be good. (Not sure if
@@ -189,19 +203,22 @@ int main() {
       // wrote out restart files, so we only need to do this if we
       // didn't just do it.  So, check the negative here:
       if (!time.check_time_gate(input.get_dt_write_restarts())) {
-	report.print(3, "Writing restart files");
+        report.print(3, "Writing restart files");
 
-	didWork = neutrals.restart_file(input.get_restartout_dir(), DoWrite);
-	if (!didWork)
-	  throw std::string("Writing Restart for Neutrals Failed!!!\n");	
+        didWork = neutrals.restart_file(input.get_restartout_dir(), DoWrite);
 
-	didWork = ions.restart_file(input.get_restartout_dir(), DoWrite);
-	if (!didWork)
-	  throw std::string("Writing Restart for Ions Failed!!!\n");	
+        if (!didWork)
+          throw std::string("Writing Restart for Neutrals Failed!!!\n");
 
-	didWork = time.restart_file(input.get_restartout_dir(), DoWrite);
-	if (!didWork)
-	  throw std::string("Writing Restart for time Failed!!!\n");	
+        didWork = ions.restart_file(input.get_restartout_dir(), DoWrite);
+
+        if (!didWork)
+          throw std::string("Writing Restart for Ions Failed!!!\n");
+
+        didWork = time.restart_file(input.get_restartout_dir(), DoWrite);
+
+        if (!didWork)
+          throw std::string("Writing Restart for time Failed!!!\n");
       }
 
       // Do some coupling here. But we have no coupling to do. Sad.
@@ -213,13 +230,14 @@ int main() {
 
   } catch (std::string error) {
     report.report_errors();
+
     if (iProc == 0) {
       std::cout << error << "\n";
       std::cout << "---- Must Exit! ----\n";
     }
   }
 
-    
+
   // End parallel tasks:
   iErr = MPI_Finalize();
 

--- a/src/neutrals.cpp
+++ b/src/neutrals.cpp
@@ -356,7 +356,7 @@ bool Neutrals::restart_file(std::string dir, bool DoRead) {
 
   try {
     if (DoRead)
-      RestartContainer.read_container_netcdf();
+      RestartContainer.read();
     else {
       RestartContainer.set_version(0.1);
       RestartContainer.set_time(0.0);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1,8 +1,6 @@
 // Copyright 2020, the Aether Development Team (see doc/dev_team.md for members)
 // Full license can be found in License.md
 
-// #include <netcdf>
-
 #include "aether.h"
 
 /* ---------------------------------------------------------------------
@@ -68,7 +66,7 @@ bool output(const Neutrals &neutrals,
       // ------------------------------------------------------------
       // Put Lon, Lat, Alt into all output containers:
 
-      if (type_output == "corners") {
+      if (type_output == "corners" || type_output == "grid") {
         // Cell Corners:
         AllOutputContainers[iOutput].
         store_variable("lon",
@@ -290,391 +288,51 @@ bool output(const Neutrals &neutrals,
       if (type_output == "moment")
         filename = "3DMMT_";
 
-      if (type_output == "corners")
+      if (type_output == "corners" || type_output == "grid")
         filename = "3DCOR_";
 
       if (type_output == "therm")
         filename = "3DTHR_";
 
-      if ((int64_t(input.get_dt_output(iOutput)) % 60) == 0)
-        filename = filename + time.get_YMD_HM0();
-      else
-        filename = filename + time.get_YMD_HMS();
-
-      if (nMembers > 1)
-        filename = filename + "_" + cMember;
-
-      filename = filename + "_" + cGrid;
-
-      report.print(0, "Writing file : " + filename);
-      AllOutputContainers[iOutput].set_filename(filename);
-
-      // ------------------------------------------------------------
-      // write output container
-
-      if (!AllOutputContainers[iOutput].write()) {
-        report.error("Error in writing output container!");
+      if (filename.length() < 5) {
+        report.print(0, "type_output : " + type_output);
+        report.error("File output type not found!");
         didWork = false;
+      } else {
+
+        if ((int64_t(input.get_dt_output(iOutput)) % 60) == 0)
+          filename = filename + time.get_YMD_HM0();
+        else
+          filename = filename + time.get_YMD_HMS();
+
+        if (nMembers > 1)
+          filename = filename + "_" + cMember;
+
+        filename = filename + "_" + cGrid;
+
+        report.print(0, "Writing file : " + filename);
+        AllOutputContainers[iOutput].set_filename(filename);
+
+        // ------------------------------------------------------------
+        // write output container
+
+        if (!AllOutputContainers[iOutput].write()) {
+          report.error("Error in writing output container!");
+          didWork = false;
+        }
       }
 
       // ------------------------------------------------------------
       // Clear variables for next time
 
       AllOutputContainers[iOutput].clear_variables();
+
     }
+    if (!didWork)
+      break;
   }
 
   report.exit(function);
   return didWork;
 }
 
-/* ---------------------------------------------------------------------
-
-   General Methods for the output containers
-
- -------------------------------------------------------------------- */
-
-// -----------------------------------------------------------------------------
-// gets the number of elements in the output container
-// -----------------------------------------------------------------------------
-
-int64_t OutputContainer::get_nElements() {
-  return elements.size();
-}
-
-// -----------------------------------------------------------------------------
-// gets the ith element arma_cube in the output container
-// -----------------------------------------------------------------------------
-
-arma_cube OutputContainer::get_element_value(int64_t iElement) {
-  arma_cube val;
-
-  if (iElement < elements.size())
-    val = elements[iElement].value;
-
-  return val;
-}
-
-// -----------------------------------------------------------------------------
-// gets the element arma_cube in the output container given name
-// -----------------------------------------------------------------------------
-
-arma_cube OutputContainer::get_element_value(std::string var_to_get) {
-  arma_cube val;
-  int64_t iElement = find_element(var_to_get);
-
-  if (iElement >= 0)
-    val = elements[iElement].value;
-
-  return val;
-}
-
-// -----------------------------------------------------------------------------
-// gets the ith element name in the output container
-// -----------------------------------------------------------------------------
-
-std::string OutputContainer::get_element_name(int64_t iElement) {
-  std::string val = "";
-
-  if (iElement < elements.size())
-    val = elements[iElement].cName;
-
-  return val;
-}
-
-// -----------------------------------------------------------------------------
-// find the element number for the given variable name
-// -----------------------------------------------------------------------------
-
-int64_t OutputContainer::find_element(std::string var_to_find) {
-  int64_t nVars = elements.size();
-  int64_t iVarSave = -1;
-
-  for (int64_t iVar = 0; iVar < nVars; iVar++)
-    if (elements[iVar].cName.compare(var_to_find) == 0)
-      iVarSave = iVar;
-
-  return iVarSave;
-}
-
-// -----------------------------------------------------------------------------
-// sets the output type to be binary
-// -----------------------------------------------------------------------------
-
-void OutputContainer::set_binary() {
-  output_type = binary_type;
-}
-
-// -----------------------------------------------------------------------------
-// sets the output type to be netcdf
-// -----------------------------------------------------------------------------
-
-void OutputContainer::set_netcdf() {
-  output_type = netcdf_type;
-}
-
-// -----------------------------------------------------------------------------
-// sets the output type to be hdf5
-// -----------------------------------------------------------------------------
-
-void OutputContainer::set_hdf5() {
-  output_type = hdf5_type;
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-
-void OutputContainer::set_directory(std::string in_dir) {
-  directory = in_dir;
-}
-
-// -----------------------------------------------------------------------------
-// Set the filename for file output.  We can increase the
-// sophistication of this system by adding on the timestamp.
-// -----------------------------------------------------------------------------
-
-void OutputContainer::set_filename(std::string in_filename) {
-  filename = in_filename;
-}
-
-// -----------------------------------------------------------------------------
-// Store variable information into the output container
-// -----------------------------------------------------------------------------
-
-void OutputContainer::store_variable(std::string name,
-                                     std::string unit,
-                                     arma_cube value) {
-  var_struct single;
-  single.cName = name;
-  single.cLongName = "";
-  single.cUnit = unit;
-  single.value = value;
-  elements.push_back(single);
-}
-
-// -----------------------------------------------------------------------------
-// Store variable information into the output container
-//   - add long_name (needed for netcdf standardization)
-// -----------------------------------------------------------------------------
-
-void OutputContainer::store_variable(std::string name,
-                                     std::string long_name,
-                                     std::string unit,
-                                     arma_cube value) {
-  var_struct single;
-  single.cName = name;
-  single.cLongName = long_name;
-  single.cUnit = unit;
-  single.value = value;
-  elements.push_back(single);
-}
-
-// -----------------------------------------------------------------------------
-// Set the time of the output file
-// -----------------------------------------------------------------------------
-
-void OutputContainer::set_time(double time) {
-  itime = time_real_to_int(time);
-}
-
-// -----------------------------------------------------------------------------
-// Set the version number of the output. This, in theory, should be
-// the version of Aether.
-// -----------------------------------------------------------------------------
-
-void OutputContainer::set_version(float in_version) {
-  version = in_version;
-}
-
-// -----------------------------------------------------------------------------
-// Clears the elements vector within the output container
-// -----------------------------------------------------------------------------
-
-void OutputContainer::clear_variables() {
-  elements.clear();
-}
-
-// -----------------------------------------------------------------------------
-// Initialize the output container
-// -----------------------------------------------------------------------------
-
-OutputContainer::OutputContainer() {
-  // Set default output type to netCDF
-#ifdef NETCDF
-  output_type = netcdf_type;
-#else
-  output_type = binary_type;
-#endif
-}
-
-// -----------------------------------------------------------------------------
-// This is the write method. Here we look at which type of file output
-// the user wants, and then output that particular type.
-// -----------------------------------------------------------------------------
-
-bool OutputContainer::write() {
-
-  bool didWork = true;
-
-  if (output_type == binary_type) {
-    didWork = write_container_header();
-
-    if (didWork)
-      didWork = write_container_binary();
-  }
-
-  if (output_type == netcdf_type)
-    didWork = write_container_netcdf();
-
-  return didWork;
-}
-
-// -----------------------------------------------------------------------------
-// display the contents of an output container to the screen
-// -----------------------------------------------------------------------------
-
-void OutputContainer::display() {
-  std::cout << "Displaying Container Information:\n";
-  std::cout << "  time : ";
-  display_itime(itime);
-  std::cout << "  nX : " << elements[0].value.n_rows << "\n";
-  std::cout << "  nY : " << elements[0].value.n_cols << "\n";
-  std::cout << "  nZ : " << elements[0].value.n_slices << "\n";
-  int64_t nVars = elements.size();
-  std::cout << "  Number of Variables : " << nVars << "\n";
-
-  for (int64_t iVar = 0; iVar < nVars; iVar++) {
-    std::cout << "  Variable " << iVar << ": " << elements[iVar].cName << "\n";
-    std::cout << "      Unit  : " << elements[iVar].cUnit << "\n";
-
-    if (elements[iVar].cLongName.length() > 0)
-      std::cout << "      Long Name  : " << elements[iVar].cLongName;
-  }
-}
-
-/* ---------------------------------------------------------------------
-
-   Output methods for binary files
-
- -------------------------------------------------------------------- */
-
-// -----------------------------------------------------------------------------
-// Write a header file for the container.  This outputs into a json
-// formatted file.
-// -----------------------------------------------------------------------------
-
-bool OutputContainer::write_container_header() {
-
-  bool didWork = true;
-  int64_t nVars = elements.size();
-  int64_t nX = elements[0].value.n_rows;
-  int64_t nY = elements[0].value.n_cols;
-  int64_t nZ = elements[0].value.n_slices;
-
-  std::vector<std::string> variables;
-  std::vector<std::string> units;
-
-  for (int64_t iVar = 0; iVar < nVars; iVar++) {
-    variables.push_back(elements[iVar].cName);
-    units.push_back(elements[iVar].cUnit);
-  }
-
-  json header = json::object({ {"version", version},
-    {"time", itime},
-    {"nVars", nVars},
-    {"nX", nX},
-    {"nY", nY},
-    {"nZ", nZ},
-    {"nLons", nX},
-    {"nLats", nY},
-    {"nAlts", nZ},
-    {"variables", variables},
-    {"units", units} });
-  std::string whole_filename = directory + "/" + filename + ".json";
-
-  try {
-    std::ofstream file(whole_filename);
-    file << header.dump(4) << "\n";
-    file.close();
-  } catch (...) {
-    report.error("Error writing header file : " + whole_filename);
-    didWork = false;
-  }
-
-  return didWork;
-}
-
-//----------------------------------------------------------------------
-// Output a given arma_cube to the binary file.
-// ----------------------------------------------------------------------
-
-void output_binary_3d(std::ofstream &binary,
-                      arma_cube value) {
-
-  // Get the size of the cube:
-
-  int64_t nX = value.n_rows;
-  int64_t nY = value.n_cols;
-  int64_t nZ = value.n_slices;
-  int64_t iX, iY, iZ, index;
-
-  int64_t nPts = nX * nY * nZ;
-  int64_t iTotalSize = nPts * sizeof(float);
-
-  // Create a temporary c-array to use to output the variable
-  float *tmp_s3gc = static_cast<float*>(malloc(iTotalSize));
-
-  // Move the data from the cube to the c-array
-
-  for (iZ = 0; iZ < nZ; iZ++) {
-    for (iY = 0; iY < nY; iY++) {
-      for (iX = 0; iX < nX; iX++) {
-        // Python ordering!
-        index = iX + iY * nX + iZ * nY * nX;
-        tmp_s3gc[index] = value(iX, iY, iZ);
-      }
-    }
-  }
-
-  // Output the data to the binary file
-  binary.write((char *) tmp_s3gc, iTotalSize);
-
-  // delete the c-array
-  free(tmp_s3gc);
-}
-
-// -----------------------------------------------------------------------------
-// dump the contents of the container out into a binary file
-// -----------------------------------------------------------------------------
-
-bool OutputContainer::write_container_binary() {
-
-  bool didWork = true;
-  std::ofstream binary;
-  std::string whole_filename = directory + "/" + filename + ".bin";
-
-  try {
-    binary.open(whole_filename, ios::binary | ios::out);
-
-    int64_t nVars = elements.size();
-
-    for (int64_t iVar = 0; iVar < nVars; iVar++)
-      output_binary_3d(binary, elements[iVar].value);
-
-    return didWork;
-  } catch (...) {
-    report.error("Error writing binary file : " + whole_filename);
-    didWork = false;
-  }
-
-  return didWork;
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -328,6 +328,7 @@ bool output(const Neutrals &neutrals,
       AllOutputContainers[iOutput].clear_variables();
 
     }
+
     if (!didWork)
       break;
   }

--- a/src/output_netcdf.cpp
+++ b/src/output_netcdf.cpp
@@ -65,9 +65,9 @@ void output_netcdf_3d(std::vector<size_t> count_start,
 // read contents of a netcdf file into an output container
 // -----------------------------------------------------------------------------
 
-int OutputContainer::read_container_netcdf() {
+bool OutputContainer::read_container_netcdf() {
 
-  int iErr = 0;
+  bool didWork = true;
   std::string whole_filename = directory + "/" + filename + ".nc";
   std::string UNITS = "units";
 
@@ -148,10 +148,10 @@ int OutputContainer::read_container_netcdf() {
   } catch (...) {
     std::cout << "Error reading netcdf file : "
               << whole_filename << "\n";
-    iErr = 1;
+    didWork = false;
   }
 
-  return iErr;
+  return didWork;
 }
 
 // -----------------------------------------------------------------------------
@@ -219,10 +219,10 @@ bool OutputContainer::write_container_netcdf() {
 
  -------------------------------------------------------------------- */
 
-int OutputContainer::read_container_netcdf() {
-  int iErr = 1;
+bool OutputContainer::read_container_netcdf() {
+  bool didWork = false;
   std::cout << "read_container_netcdf is not working!\n";
-  return iErr;
+  return didWork;
 }
 
 bool OutputContainer::write_container_netcdf() {

--- a/src/read_input_file.cpp
+++ b/src/read_input_file.cpp
@@ -61,7 +61,7 @@ bool Inputs::read_inputs_json(Times &time) {
 
     //change planet file to the one specified on aether.json:
     if (isOk)
-      settings["PlanetSpeciesFile"] = get_setting_str("PlanetFile");
+      settings["PlanetSpeciesFile"] = get_setting_str("Planet", "file");
 
     std::string planet_filename = get_setting_str("PlanetSpeciesFile");
     report.print(1, "Using planet file : " + planet_filename);

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -31,6 +31,14 @@ Times::Times() {
 }
 
 // -----------------------------------------------------------------------------
+// This sets the end of the initialization time
+// -----------------------------------------------------------------------------
+
+void Times::set_start_time_loop() {
+  time(&sys_time_start_time_loop);
+}
+
+// -----------------------------------------------------------------------------
 // This is for restarting the code. Either write or read the time.
 // -----------------------------------------------------------------------------
 
@@ -279,7 +287,7 @@ void Times::display() {
   time(&sys_time_current);
   walltime =
     static_cast<double>(sys_time_current) -
-    static_cast<double>(sys_time_start);
+    static_cast<double>(sys_time_start_time_loop);
 
   double elapsed_simulation_time = current - restart;
   double total_simulation_time = end - restart;

--- a/tests/restart_cubesphere/aether.first.json
+++ b/tests/restart_cubesphere/aether.first.json
@@ -1,0 +1,26 @@
+
+{
+    "Debug" : {
+	"iVerbose" : 0,
+	"dt" : 10.0},
+
+    "GeoBlockSize" : {
+	"nLons" : 18,
+	"nLats" : 18,
+	"nAlts" : 50},
+
+    "StartTime" : [2011, 3, 20, 0, 0, 0],
+    "EndTime" : [2011, 3, 20, 0, 15, 0],
+
+    "Electrodynamics" : {
+	"File" : "UA/inputs/b20110320n_omni.bin"},
+
+    "OmniwebFiles" : ["UA/inputs/omni_20110319.txt"],
+
+    "CubeSphere" : {
+	"is" : true},
+
+    "Restart" : {
+	"do" : false,
+	"dt" : 900.0}
+}

--- a/tests/restart_cubesphere/aether.second.json
+++ b/tests/restart_cubesphere/aether.second.json
@@ -1,0 +1,26 @@
+
+{
+    "Debug" : {
+	"iVerbose" : 0,
+	"dt" : 10.0},
+
+    "GeoBlockSize" : {
+	"nLons" : 18,
+	"nLats" : 18,
+	"nAlts" : 50},
+    
+    "StartTime" : [2011, 3, 20, 0, 0, 0],
+    "EndTime" : [2011, 3, 20, 0, 30, 0],
+
+    "Electrodynamics" : {
+	"File" : "UA/inputs/b20110320n_omni.bin"},
+    
+    "OmniwebFiles" : ["UA/inputs/omni_20110319.txt"],
+    
+    "CubeSphere" : {
+	"is" : true},
+
+    "Restart" : {
+	"do" : true,
+	"dt" : 900.0}
+}

--- a/tests/restart_cubesphere/aether.whole.json
+++ b/tests/restart_cubesphere/aether.whole.json
@@ -1,0 +1,26 @@
+
+{
+    "Debug" : {
+	"iVerbose" : 0,
+	"dt" : 10.0},
+
+    "GeoBlockSize" : {
+	"nLons" : 18,
+	"nLats" : 18,
+	"nAlts" : 50},
+    
+    "StartTime" : [2011, 3, 20, 0, 0, 0],
+    "EndTime" : [2011, 3, 20, 0, 30, 0],
+
+    "Electrodynamics" : {
+	"File" : "UA/inputs/b20110320n_omni.bin"},
+    
+    "OmniwebFiles" : ["UA/inputs/omni_20110319.txt"],
+    
+    "CubeSphere" : {
+	"is" : true},
+
+    "Restart" : {
+	"do" : false,
+	"dt" : 900.0}
+}

--- a/tests/restart_cubesphere/run_test.sh
+++ b/tests/restart_cubesphere/run_test.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+rm -rf run.halves run.whole
+
+cp -R ../../share/run ./run.halves
+cd run.halves
+# first part of the run
+cp ../aether.first.json ./aether.json
+mpirun -np 6 ./aether
+cd UA ; rm -f restartIn ; cp -R restartOut restartIn ; cd ..
+# second part of the run
+cp ../aether.second.json ./aether.json
+mpirun -np 6 ./aether
+# plot the output
+cd UA/output
+../../../../../srcPython/postAether.py -alt=-1 -rm
+
+# [O]:
+aether_plot_simple.py -var=density_O -alt=250 3DALL_20110320_003000.nc -polar
+# Eastward Ion Velocity
+aether_plot_simple.py -var=velocity_east_ion -alt=250 3DALL_20110320_003000.nc -polar
+# [e-]
+aether_plot_simple.py -var=density_e- -alt=250 3DALL_20110320_003000.nc -polar
+
+cd ../../..
+
+cp -R ../../share/run ./run.whole
+cd run.whole
+cp ../aether.whole.json ./aether.json
+mpirun -np 6 ./aether
+# plot the output
+cd UA/output
+../../../../../srcPython/postAether.py -alt=-1 -rm
+# [O]:
+aether_plot_simple.py -var=density_O -alt=250 3DALL_20110320_003000.nc -polar
+# Eastward Ion Velocity 
+aether_plot_simple.py -var=velocity_east_ion -alt=250 3DALL_20110320_003000.nc -polar
+# [e-]
+aether_plot_simple.py -var=density_e- -alt=250 3DALL_20110320_003000.nc -polar
+
+cd ../../..
+
+# you can then look at:
+# restarted run results: run.halves/UA/output/*.png
+# whole run results: run.whole/UA/output/*.png
+# using whatever viewer you have

--- a/tests/restarts/aether.first.json
+++ b/tests/restarts/aether.first.json
@@ -3,18 +3,20 @@
 
     "Debug" : {
 	"iVerbose" : 0,
-	"dt" : 60.0},
+	"dt" : 10.0},
 
-    "Mysetting" : {
-	"setting1" : "this_is_an_example",
-	"setting2" : 42,
-	"setting3" : true},
-
+    "GeoBlockSize" : {
+	"nLons" : 18,
+	"nLats" : 18,
+	"nAlts" : 50},
+    
     "StartTime" : [2011, 3, 20, 0, 0, 0],
-    "EndTime" : [2011, 3, 20, 0, 45, 0],
+    "EndTime" : [2011, 3, 20, 0, 15, 0],
 
+    "Electrodynamics" : {
+	"File" : "UA/inputs/b20110320n_omni.bin"},
+    
     "OmniwebFiles" : ["UA/inputs/omni_20110319.txt"],
-    "ElectrodynamicsFile" : "UA/inputs/b20110320n_omni.bin",
     
     "Restart" : {
 	"do" : false,

--- a/tests/restarts/aether.second.json
+++ b/tests/restarts/aether.second.json
@@ -3,18 +3,20 @@
 
     "Debug" : {
 	"iVerbose" : 0,
-	"dt" : 60.0},
+	"dt" : 10.0},
 
-    "Mysetting" : {
-	"setting1" : "this_is_an_example",
-	"setting2" : 42,
-	"setting3" : true},
-
+    "GeoBlockSize" : {
+	"nLons" : 18,
+	"nLats" : 18,
+	"nAlts" : 50},
+    
     "StartTime" : [2011, 3, 20, 0, 0, 0],
-    "EndTime" : [2011, 3, 20, 1, 0, 0],
+    "EndTime" : [2011, 3, 20, 0, 30, 0],
 
+    "Electrodynamics" : {
+	"File" : "UA/inputs/b20110320n_omni.bin"},
+    
     "OmniwebFiles" : ["UA/inputs/omni_20110319.txt"],
-    "ElectrodynamicsFile" : "UA/inputs/b20110320n_omni.bin",
     
     "Restart" : {
 	"do" : true,

--- a/tests/restarts/aether.whole.json
+++ b/tests/restarts/aether.whole.json
@@ -3,18 +3,20 @@
 
     "Debug" : {
 	"iVerbose" : 0,
-	"dt" : 60.0},
+	"dt" : 10.0},
 
-    "Mysetting" : {
-	"setting1" : "this_is_an_example",
-	"setting2" : 42,
-	"setting3" : true},
-
+    "GeoBlockSize" : {
+	"nLons" : 18,
+	"nLats" : 18,
+	"nAlts" : 50},
+    
     "StartTime" : [2011, 3, 20, 0, 0, 0],
-    "EndTime" : [2011, 3, 20, 1, 0, 0],
+    "EndTime" : [2011, 3, 20, 0, 30, 0],
 
+    "Electrodynamics" : {
+	"File" : "UA/inputs/b20110320n_omni.bin"},
+    
     "OmniwebFiles" : ["UA/inputs/omni_20110319.txt"],
-    "ElectrodynamicsFile" : "UA/inputs/b20110320n_omni.bin",
     
     "Restart" : {
 	"do" : false,

--- a/tests/restarts/run_test.sh
+++ b/tests/restarts/run_test.sh
@@ -2,21 +2,6 @@
 
 rm -rf run.halves run.whole
 
-cp -R ../../share/run ./run.whole
-cd run.whole
-cp ../aether.whole.json ./aether.json
-./aether
-# plot the output
-cd UA/output
-# [O]:
-run_plot_model_results.py -var=3 -alt=250 3DALL_20110320_010000.nc
-# Tn:
-run_plot_model_results.py -var=14 -alt=250 3DALL_20110320_010000.nc
-# [e-]
-run_plot_model_results.py -var=23 -alt=250 3DALL_20110320_010000.nc
-
-cd ../../..
-
 cp -R ../../share/run ./run.halves
 cd run.halves
 # first part of the run
@@ -28,12 +13,30 @@ cp ../aether.second.json ./aether.json
 ./aether
 # plot the output
 cd UA/output
+../../../../../srcPython/postAether.py -alt=-1 -rm
+
 # [O]:
-run_plot_model_results.py -var=3 -alt=250 3DALL_20110320_010000.nc
+aether_plot_simple.py -var=density_O -alt=250 3DALL_20110320_003000.nc
 # Tn:
-run_plot_model_results.py -var=14 -alt=250 3DALL_20110320_010000.nc
+aether_plot_simple.py -var=Temperature_neutral -alt=250 3DALL_20110320_003000.nc
 # [e-]
-run_plot_model_results.py -var=23 -alt=250 3DALL_20110320_010000.nc
+aether_plot_simple.py -var=density_e- -alt=250 3DALL_20110320_003000.nc
+
+cd ../../..
+
+cp -R ../../share/run ./run.whole
+cd run.whole
+cp ../aether.whole.json ./aether.json
+./aether
+# plot the output
+cd UA/output
+../../../../../srcPython/postAether.py -alt=-1 -rm
+# [O]:
+aether_plot_simple.py -var=density_O -alt=250 3DALL_20110320_003000.nc
+# Tn:
+aether_plot_simple.py -var=Temperature_neutral -alt=250 3DALL_20110320_003000.nc
+# [e-]
+aether_plot_simple.py -var=density_e- -alt=250 3DALL_20110320_003000.nc
 
 cd ../../..
 


### PR DESCRIPTION
# Description

Addresses #103 

When the cubesphere was fully implemented, the restarts stopped working. So, this was solved by no restarting the grid for cubespheres. That is sort of a hack, but there are so many variables that are calculated for the cubesphere that it doesn't make much sense to actually restart it.

Further, restarts have never worked without netCDF files. A reader for binary file containers is included in this pull. That solves the problem of the netCDFs.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce.

## Test configuration

* Operating system: mac and ubuntu
* Compiler, version number: gcc 13 (mac) and gcc 11 (ubuntu)
* didn't use netcdfs on either.

# Checklist:

- [N/A] Make sure you are merging into the ``develop`` (not ``master``) branch
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [N/A] Add a note to ``CHANGELOG.md``, summarizing the changes
