### PR TITLE
[BUGS]: Some quick i/o bugfixes

### DIFF
--- a/share/run/UA/inputs/defaults.json
+++ b/share/run/UA/inputs/defaults.json
@@ -101,7 +101,8 @@
     "Sources" : {
 	"Grid" : {
 	    "Centripetal" : true,
-		"Coriolis" : true },
+		"Coriolis" : true,
+		"Cent_acc": true },
 	"Neutrals" : {
 	    "NO_cool" : false,
 	    "O_cool": false } },

--- a/src/inputs.cpp
+++ b/src/inputs.cpp
@@ -547,10 +547,13 @@ std::vector<std::string> Inputs::get_omniweb_files() {
 
 precision_t Inputs::get_dt_output(int iOutput) {
   precision_t value = 0.0;
-  int nOutputs = settings.at("Outputs").at("type").size();
+  int nOutputs = settings.at("Outputs").at("dt").size();
 
   if (iOutput < nOutputs)
     value = settings.at("Outputs").at("dt").at(iOutput);
+  else{
+    report.error("Output Error; more output types than dt's provided.");
+  }
 
   return value;
 }

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -177,7 +177,7 @@ int main() {
       didWork = output(neutralsMag, ionsMag, mGrid, time, planet);
     }
     if (!didWork)
-      throw std::string("output failed!");
+      throw std::string("Initial output failed!");
 
     // This is advancing now... We are not coupling, so set dt_couple to the
     // end of the simulation

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -251,7 +251,7 @@ bool output(const Neutrals &neutrals,
                                                     grid.radius_scgc);
       }
 
-      if (type_output == "bfield") {
+      if (type_output == "bfield" || type_output == "ions") {
         AllOutputContainers[iOutput].store_variable("mlat",
                                                     "Magnetic Latitude",
                                                     "degrees",

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -87,7 +87,14 @@ bool output(const Neutrals &neutrals,
 
   for (int iOutput = 0; iOutput < nOutputs; iOutput++) {
 
-    if (time.check_time_gate(input.get_dt_output(iOutput))) {
+    // make sure the output dt is set correctly. Otherwise these errors aren't caught correctly.
+    precision_t dt_output = input.get_dt_output(iOutput);
+    if (dt_output == 0.0){
+      report.exit(function);
+      return false;
+    }
+
+    if (time.check_time_gate(dt_output)) {
 
       // ------------------------------------------------------------
       // Store time in all of the files:


### PR DESCRIPTION
# Make sure dt is specified for each output type, and change default inputs

Some super minor bug fixes. And a little new feature:
- If there were more output types than dt's, there would be an out-of-range json error and no more info. this catches those errors.
- `Cent_acc` was not included in the default input file
  - `Centripetal` and `Cent_acc` are both checked? IDK if this is right.
  - See [here](https://github.com/AetherModel/Aether/blob/b429fe2e06dde36701f30a9f8eba113877786132/src/inputs.cpp#L760C1-L778C2). Centripetal is not used, only calc_cent_acc - in main
- If `Ions` output type is specified, output the magnetic coordinates
  - MLT is not right, but the magnetic coordinates are output


## Type of change

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)


# How Has This Been Tested?

Tested with correct, and incorrect input files. Errors were caught correctly.

## Test configuration

-WSL Ubuntu gcc/g++ 13


# Checklist:

- [N/A] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [N/A] Add a note to ``CHANGELOG.md``, summarizing the changes
